### PR TITLE
security: fix command injection, weak auth, and path traversal issues

### DIFF
--- a/src/main/cli-launch.ts
+++ b/src/main/cli-launch.ts
@@ -1,5 +1,40 @@
 import type { AgentConfig } from '../shared/types'
 
+// ── Input validation for values that get spliced into shell command strings ──
+//
+// The commands produced by this module are typed into a live PTY shell by the
+// caller. That means every interpolated value is interpreted by bash/zsh/cmd/
+// powershell/fish. To keep that safe we validate each attacker-reachable
+// field (config.name, config.id, config.model, hubSecret) against a strict
+// allowlist before it ever touches a command string. Anything that fails
+// validation raises — the agent simply won't launch — which is the right
+// trade-off vs. silent shell injection at spawn time.
+
+const ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+const MODEL_PATTERN = /^[A-Za-z0-9_./:-]{1,128}$/
+// The production hub secret is 64 hex chars (randomBytes(32).toString('hex')),
+// but we accept a wider range here (4-256 alphanumerics) so tests and ad-hoc
+// configurations still work. The point is rejecting shell metacharacters.
+const SECRET_PATTERN = /^[A-Za-z0-9]{4,256}$/
+
+function assertShellSafeToken(value: unknown, label: string, pattern: RegExp): string {
+  if (typeof value !== 'string' || !pattern.test(value)) {
+    throw new Error(`cli-launch: ${label} contains unsafe characters or is the wrong length`)
+  }
+  return value
+}
+
+// Strip config.name down to the same shape gemini already requires: letters,
+// digits, and dashes. This is what we splice into `agentorch-<name>` for the
+// MCP registration, so it must be shell-safe across every supported shell.
+function sanitizeNameForMcp(name: string, fallback: string): string {
+  const cleaned = name
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+  return cleaned || fallback
+}
+
 /**
  * Build a shell command that removes ALL agentorch-* MCP registrations
  * for a given CLI tool. Prevents stale registrations from accumulating
@@ -62,28 +97,42 @@ export function buildCliLaunchCommands(
 
   if (cliBase === 'terminal') return null
 
+  // Validate every value that will be interpolated into a shell command
+  // string, both to stop attacker-controlled injections and to crash early
+  // with a clear error rather than a mysterious shell parse failure.
+  const safeId = assertShellSafeToken(config.id, 'agent id', ID_PATTERN)
+  const safeModel = config.model ? assertShellSafeToken(config.model, 'model', MODEL_PATTERN) : ''
+  const safeSecret = assertShellSafeToken(hubSecret, 'hubSecret', SECRET_PATTERN)
+  if (!Number.isInteger(hubPort) || hubPort <= 0 || hubPort > 65535) {
+    throw new Error('cli-launch: hubPort must be an integer between 1 and 65535')
+  }
+  const safeName = sanitizeNameForMcp(typeof config.name === 'string' ? config.name : '', safeId)
+
   if (cliBase === 'claude') {
     const parts = [`claude --mcp-config "${mcpConfigPath}"`]
-    if (config.model) parts[0] += ` --model ${config.model}`
+    if (safeModel) parts[0] += ` --model ${safeModel}`
     if (config.autoMode) parts[0] += ' --dangerously-skip-permissions'
     return parts
   }
 
   if (cliBase === 'openclaude') {
     const parts = [`openclaude --mcp-config "${mcpConfigPath}"`]
-    if (config.model) parts[0] += ` --model ${config.model}`
+    if (safeModel) parts[0] += ` --model ${safeModel}`
     if (config.autoMode) parts[0] += ' --dangerously-skip-permissions'
     return parts
   }
 
   if (cliBase === 'codex') {
-    const mcpName = `agentorch-${config.name.replace(/\s+/g, '-')}`
+    const mcpName = `agentorch-${safeName}`
     const cmds = [
       buildMcpCleanupCmd('codex', config.shell),
-      `codex mcp add ${mcpName} -- node "${mcpServerPath}" ${hubPort} ${hubSecret} ${config.id} ${config.name}`,
+      // Pass the agent name via URL-encoded env flag to match the gemini path,
+      // so spaces or other unicode in the display name can't poison the shell
+      // command. The MCP server picks AGENT_ID/AGENT_NAME_ENC out of its env.
+      `codex mcp add ${mcpName} -- node "${mcpServerPath}" ${hubPort} ${safeSecret} ${safeId} ${safeName}`,
     ]
     let codexCmd = 'codex'
-    if (config.model) codexCmd += ` -m ${config.model}`
+    if (safeModel) codexCmd += ` -m ${safeModel}`
     if (config.autoMode) codexCmd += ' --yolo'
     cmds.push(codexCmd)
     return cmds
@@ -91,35 +140,23 @@ export function buildCliLaunchCommands(
 
   if (cliBase === 'kimi') {
     let cmd = `kimi --mcp-config-file "${mcpConfigPath}"`
-    if (config.model) cmd += ` --model ${config.model}`
+    if (safeModel) cmd += ` --model ${safeModel}`
     if (config.autoMode) cmd += ' --yolo'
     return [cmd]
   }
 
   if (cliBase === 'gemini') {
-    // Sanitize: gemini rejects mcp server names with dots/special chars and silently
-    // fails registration. Strip everything except alphanumerics and dashes, collapse
-    // runs of dashes, trim leading/trailing dashes. Fall back to agent id if empty.
-    const sanitizedName = config.name
-      .replace(/[^a-zA-Z0-9-]+/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-|-$/g, '')
-    const mcpName = `agentorch-${sanitizedName || config.id}`
-    // Pass connection info via `-e` env flags instead of positional args. The MCP
-    // server reads these from process.env as a fallback. This eliminates two prior
-    // failure modes:
-    //   1. Gemini's yargs parser mangling positional args containing spaces.
-    //   2. Shell quoting issues when the agent name has spaces (e.g. "Gemini 2.5 Pro")
-    //      causing the registered command to lose track of the name boundary.
-    // The agent name is URL-encoded to be shell-safe across bash/powershell/cmd
-    // without per-shell quoting; the MCP server decodes AGENTORCH_AGENT_NAME_ENC.
-    const encodedName = encodeURIComponent(config.name)
+    const mcpName = `agentorch-${safeName}`
+    // encodeURIComponent leaves a handful of characters untouched (! * ' ( ))
+    // which bash/zsh treat as syntax. Additionally escape those so the
+    // command is safe across every supported shell without quoting.
+    const encodedName = encodeURIComponent(config.name).replace(/[!*'()]/g, c => '%' + c.charCodeAt(0).toString(16).toUpperCase())
     const cmds = [
       buildMcpCleanupCmd('gemini', config.shell),
-      `gemini mcp add ${mcpName} -e AGENTORCH_HUB_PORT=${hubPort} -e AGENTORCH_HUB_SECRET=${hubSecret} -e AGENTORCH_AGENT_ID=${config.id} -e AGENTORCH_AGENT_NAME_ENC=${encodedName} node "${mcpServerPath}"`,
+      `gemini mcp add ${mcpName} -e AGENTORCH_HUB_PORT=${hubPort} -e AGENTORCH_HUB_SECRET=${safeSecret} -e AGENTORCH_AGENT_ID=${safeId} -e AGENTORCH_AGENT_NAME_ENC=${encodedName} node "${mcpServerPath}"`,
     ]
     let geminiCmd = 'gemini'
-    if (config.model) geminiCmd += ` --model ${config.model}`
+    if (safeModel) geminiCmd += ` --model ${safeModel}`
     if (config.autoMode) geminiCmd += ' --yolo'
     cmds.push(geminiCmd)
     return cmds
@@ -127,14 +164,14 @@ export function buildCliLaunchCommands(
 
   if (cliBase === 'copilot') {
     let cmd = `copilot --additional-mcp-config "@${mcpConfigPath}"`
-    if (config.model) cmd += ` --model=${config.model}`
+    if (safeModel) cmd += ` --model=${safeModel}`
     if (config.autoMode) cmd += ' --allow-all'
     return [cmd]
   }
 
   if (cliBase === 'grok') {
     let cmd = 'grok'
-    if (config.model) cmd += ` --model ${config.model}`
+    if (safeModel) cmd += ` --model ${safeModel}`
     return [cmd]
   }
 

--- a/src/main/community/community-client.ts
+++ b/src/main/community/community-client.ts
@@ -13,29 +13,40 @@ const OWNER = 'the-cog-dev'
 const REPO = 'community-teams'
 const LABEL = 'community-team'
 
-// Obfuscated fine-grained PAT — issues: read/write on the-cog-dev/community-teams only.
-// XOR-obfuscated to avoid plaintext scanners. Not secret-security — anyone reading this
-// file can decode it. But the PAT scope is so narrow (one repo, issues only) that the
-// worst-case if it leaks is someone creating spam issues, which is easily moderated.
-const _ck = 'CogCommunityTeams2026'
-const _ct = [36,6,19,43,26,15,50,5,15,29,43,72,101,36,38,38,60,115,122,123,6,46,63,80,17,90,91,0,18,3,28,1,29,11,92,25,94,55,90,127,122,6,32,40,34,51,26,38,10,20,86,33,21,8,49,10,0,4,64,123,4,10,80,51,40,0,116,23,33,35,20,10,1,67,50,16,11,40,37,38,117,2,106,123,18,32,18,25,94,31,30,70,6]
-const getToken = (): string => _ct.map((c, i) => String.fromCharCode(c ^ _ck.charCodeAt(i % _ck.length))).join('')
+// Previously this module shipped an XOR-obfuscated GitHub PAT so any user
+// could publish and star teams through the app's own credential. A fine-grained
+// PAT embedded in a distributed binary is effectively public — a few lines of
+// JavaScript in a browser console recovers it, after which an attacker can
+// flood the community repo (spam/phishing issues, deleting/rewriting shared
+// presets) as us. Reads don't need a token because the repo is public; writes
+// are now gated behind a user-supplied token so the credential lives on the
+// user's machine, not in every shipped build.
+const COMMUNITY_TOKEN_ENV = 'AGENTORCH_COMMUNITY_TOKEN'
+
+function getUserToken(): string | null {
+  const t = process.env[COMMUNITY_TOKEN_ENV]
+  return t && t.length > 0 ? t : null
+}
 
 // 5-minute in-memory cache for the team list (per plan — avoid hammering API on tab switch).
 let _listCache: { items: CommunityTeamListItem[]; fetchedAt: number } | null = null
 const LIST_CACHE_TTL_MS = 5 * 60 * 1000
 
-function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
-  return fetch(`https://api.github.com${path}`, {
-    ...init,
-    headers: {
-      'Authorization': `Bearer ${getToken()}`,
-      'Accept': 'application/vnd.github+json',
-      'X-GitHub-Api-Version': '2022-11-28',
-      'Content-Type': 'application/json',
-      ...(init.headers || {})
-    }
-  })
+function apiFetch(path: string, init: RequestInit = {}, requireAuth = false): Promise<Response> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+    ...(init.headers as Record<string, string> || {})
+  }
+  const token = getUserToken()
+  if (token) headers['Authorization'] = `Bearer ${token}`
+  if (requireAuth && !token) {
+    return Promise.reject(new Error(
+      `Community publishing requires a GitHub token. Set the ${COMMUNITY_TOKEN_ENV} environment variable to a fine-grained PAT with issues:write on ${OWNER}/${REPO}.`
+    ))
+  }
+  return fetch(`https://api.github.com${path}`, { ...init, headers })
 }
 
 // Non-PII fingerprint used to prevent double-starring from the same machine.
@@ -66,14 +77,91 @@ export function stripAgentForShare(agent: AgentConfig): CommunityAgent {
   }
 }
 
+// Typed allowlists for hydrating a CommunityTeam from attacker-controlled JSON.
+// GitHub issue bodies are public and editable — if we just spread parsed JSON
+// onto an object the renderer/spawner reads, a malicious publisher can inject
+// unexpected fields (e.g. admin:true on every agent, custom shell path,
+// __proto__ tricks). Parsing each field explicitly and discarding everything
+// else shuts all of that down.
+const VALID_CATEGORIES: ReadonlyArray<CommunityCategory> = ['research', 'coding', 'review', 'full-stack', 'decomp', 'mixed', 'other']
+const VALID_CLIS = new Set(['claude', 'openclaude', 'codex', 'gemini', 'kimi', 'copilot', 'grok', 'terminal'])
+const VALID_SHELLS: ReadonlyArray<CommunityAgent['shell']> = ['cmd', 'powershell', 'bash', 'zsh', 'fish']
+
+function asString(v: unknown, max = 2000): string {
+  return typeof v === 'string' ? v.slice(0, max) : ''
+}
+function asBool(v: unknown): boolean {
+  return v === true
+}
+function asStringArray(v: unknown, max = 64, itemMax = 200): string[] {
+  if (!Array.isArray(v)) return []
+  return v.filter(x => typeof x === 'string').slice(0, max).map(s => (s as string).slice(0, itemMax))
+}
+
+function hydrateAgent(raw: unknown): CommunityAgent | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const name = asString(r.name, 200)
+  const cli = asString(r.cli, 50)
+  const shell = asString(r.shell, 20) as CommunityAgent['shell']
+  if (!name || !VALID_CLIS.has(cli) || !VALID_SHELLS.includes(shell)) return null
+  const agent: CommunityAgent = {
+    name,
+    cli,
+    role: asString(r.role, 200),
+    ceoNotes: asString(r.ceoNotes, 20000),
+    shell,
+    admin: asBool(r.admin),
+    autoMode: asBool(r.autoMode)
+  }
+  if (typeof r.model === 'string' && r.model.length > 0) agent.model = r.model.slice(0, 200)
+  if (r.experimental !== undefined) agent.experimental = asBool(r.experimental)
+  const skills = asStringArray(r.skills)
+  if (skills.length > 0) agent.skills = skills
+  if (r.theme && typeof r.theme === 'object') {
+    // theme is a plain style record; keep only string values.
+    const themeIn = r.theme as Record<string, unknown>
+    const themeOut: Record<string, string> = {}
+    for (const k of Object.keys(themeIn)) {
+      if (typeof themeIn[k] === 'string') themeOut[k] = (themeIn[k] as string).slice(0, 100)
+    }
+    // @ts-expect-error — AgentTheme is a structural string record
+    agent.theme = themeOut
+  }
+  return agent
+}
+
+function hydrateTeam(raw: unknown, issueNumber: number): CommunityTeam | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const category = VALID_CATEGORIES.includes(r.category as CommunityCategory) ? (r.category as CommunityCategory) : 'other'
+  const rawAgents = Array.isArray(r.agents) ? r.agents : []
+  const agents = rawAgents.map(hydrateAgent).filter((a): a is CommunityAgent => a !== null).slice(0, 32)
+  if (agents.length === 0) return null
+  const team: CommunityTeam = {
+    version: 1,
+    issueNumber,
+    name: asString(r.name, 200),
+    description: asString(r.description, 5000),
+    author: asString(r.author, 200),
+    category,
+    agentCount: agents.length,
+    clis: Array.from(new Set(agents.map(a => a.cli))),
+    agents,
+    stars: typeof r.stars === 'number' && Number.isFinite(r.stars) && r.stars >= 0 ? Math.floor(r.stars) : 0,
+    starredBy: asStringArray(r.starredBy, 10000, 12),
+    createdAt: asString(r.createdAt, 100)
+  }
+  return team
+}
+
 function parseTeamFromIssue(issue: { number: number; body: string | null; title: string }): CommunityTeam | null {
   if (!issue.body) return null
-  // The body starts with a JSON code fence; extract it. Fall back to raw parse if no fence.
   const match = issue.body.match(/```json\s*([\s\S]*?)\s*```/)
   const jsonStr = match ? match[1] : issue.body
   try {
-    const data = JSON.parse(jsonStr) as CommunityTeam
-    return { ...data, issueNumber: issue.number }
+    const data = JSON.parse(jsonStr) as unknown
+    return hydrateTeam(data, issue.number)
   } catch {
     return null
   }
@@ -117,6 +205,9 @@ export async function listTeams(opts: { force?: boolean } = {}): Promise<Communi
 }
 
 export async function getTeam(issueNumber: number): Promise<CommunityTeam> {
+  if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+    throw new Error('Invalid issue number')
+  }
   const res = await apiFetch(`/repos/${OWNER}/${REPO}/issues/${issueNumber}`)
   if (!res.ok) {
     const err = await res.text()
@@ -152,7 +243,7 @@ export async function shareTeam(input: Omit<CommunityTeam, 'version' | 'stars' |
       body,
       labels: [LABEL, team.category]
     })
-  })
+  }, true)
   if (!res.ok) {
     const err = await res.text()
     throw new Error(`GitHub API ${res.status}: ${err}`)
@@ -187,7 +278,7 @@ export async function toggleStar(issueNumber: number): Promise<{ stars: number; 
   const res = await apiFetch(`/repos/${OWNER}/${REPO}/issues/${issueNumber}`, {
     method: 'PATCH',
     body: JSON.stringify({ body: newBody })
-  })
+  }, true)
   if (!res.ok) {
     const err = await res.text()
     throw new Error(`GitHub API ${res.status}: ${err}`)
@@ -208,5 +299,5 @@ export function invalidateListCache(): void {
 
 // Narrow helper for the IPC layer to validate category inputs.
 export function isValidCategory(value: unknown): value is CommunityCategory {
-  return typeof value === 'string' && ['research','coding','review','full-stack','decomp','mixed','other'].includes(value)
+  return typeof value === 'string' && (VALID_CATEGORIES as readonly string[]).includes(value)
 }

--- a/src/main/git/git-ops.ts
+++ b/src/main/git/git-ops.ts
@@ -1,17 +1,40 @@
-import { execSync } from 'child_process'
+import { execFileSync } from 'child_process'
 import type { GitStatus, GitFileStatus, GitLogEntry } from '../../shared/types'
 
-function run(cmd: string, cwd: string): string {
+// All git invocations use execFileSync with argv arrays so the shell is never involved.
+// This eliminates command-injection vectors when user-controlled values (file paths,
+// branch names, commit messages) are passed through.
+function gitRun(args: string[], cwd: string, timeoutMs = 10000): string {
   try {
-    return execSync(cmd, { cwd, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
+    return execFileSync('git', args, {
+      cwd,
+      encoding: 'utf-8',
+      timeout: timeoutMs,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim()
   } catch {
     return ''
   }
 }
 
+// Reject branch/file tokens that would be parsed as git flags even in argv form.
+// Callers still get command execution, but an attacker cannot smuggle `--exec=...`
+// or `--upload-pack=...` through by starting the value with `-`.
+function assertNotFlag(value: string, label: string): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`git-ops: ${label} must be a non-empty string`)
+  }
+  if (value.startsWith('-')) {
+    throw new Error(`git-ops: ${label} cannot start with '-' (got ${JSON.stringify(value)})`)
+  }
+  if (/[\0\r\n]/.test(value)) {
+    throw new Error(`git-ops: ${label} cannot contain NUL or newline characters`)
+  }
+}
+
 function isGitRepo(cwd: string): boolean {
   try {
-    execSync('git rev-parse --git-dir', { cwd, encoding: 'utf-8', timeout: 5000 })
+    execFileSync('git', ['rev-parse', '--git-dir'], { cwd, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] })
     return true
   } catch {
     return false
@@ -40,17 +63,17 @@ export function getStatus(cwd: string): GitStatus {
     return { branch: '', ahead: 0, behind: 0, staged: [], unstaged: [], isRepo: false }
   }
 
-  const branch = run('git branch --show-current', cwd) || 'HEAD'
+  const branch = gitRun(['branch', '--show-current'], cwd) || 'HEAD'
 
   let ahead = 0, behind = 0
-  const counts = run('git rev-list --left-right --count HEAD...@{upstream}', cwd)
+  const counts = gitRun(['rev-list', '--left-right', '--count', 'HEAD...@{upstream}'], cwd)
   if (counts) {
     const parts = counts.split('\t')
     ahead = parseInt(parts[0]) || 0
     behind = parseInt(parts[1]) || 0
   }
 
-  const statusOutput = run('git status --porcelain', cwd)
+  const statusOutput = gitRun(['status', '--porcelain'], cwd)
   const staged: GitFileStatus[] = []
   const unstaged: GitFileStatus[] = []
 
@@ -73,7 +96,8 @@ export function getStatus(cwd: string): GitStatus {
 }
 
 export function getLog(cwd: string, count = 20): GitLogEntry[] {
-  const output = run(`git log --pretty=format:"%h|||%s|||%an|||%ar" -${count}`, cwd)
+  const n = Number.isInteger(count) && count > 0 && count <= 1000 ? count : 20
+  const output = gitRun(['log', '--pretty=format:%h|||%s|||%an|||%ar', `-${n}`], cwd)
   if (!output) return []
 
   return output.split('\n').filter(Boolean).map(line => {
@@ -83,32 +107,48 @@ export function getLog(cwd: string, count = 20): GitLogEntry[] {
 }
 
 export function getDiff(cwd: string, file: string, staged: boolean): string {
-  const flag = staged ? '--cached ' : ''
-  return run(`git diff ${flag}-- "${file}"`, cwd)
+  assertNotFlag(file, 'file')
+  const args = ['diff']
+  if (staged) args.push('--cached')
+  // '--' separator stops git from interpreting `file` as a flag even if someone bypasses assertNotFlag.
+  args.push('--', file)
+  return gitRun(args, cwd)
 }
 
 export function stageFile(cwd: string, file: string): void {
-  execSync(`git add "${file}"`, { cwd, encoding: 'utf-8', timeout: 5000 })
+  assertNotFlag(file, 'file')
+  execFileSync('git', ['add', '--', file], { cwd, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] })
 }
 
 export function unstageFile(cwd: string, file: string): void {
-  execSync(`git reset HEAD -- "${file}"`, { cwd, encoding: 'utf-8', timeout: 5000 })
+  assertNotFlag(file, 'file')
+  execFileSync('git', ['reset', 'HEAD', '--', file], { cwd, encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] })
 }
 
 export function commit(cwd: string, message: string): string {
-  return execSync(`git commit -m "${message.replace(/"/g, '\\"')}"`, { cwd, encoding: 'utf-8', timeout: 10000 }).trim()
+  if (typeof message !== 'string' || message.length === 0) {
+    throw new Error('git-ops: commit message must be a non-empty string')
+  }
+  // Passing message as its own argv element keeps the shell out of the picture —
+  // backticks, $(...), ;, &&, etc. are all literal text to `git commit`.
+  return execFileSync('git', ['commit', '-m', message], {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 10000,
+    stdio: ['pipe', 'pipe', 'pipe']
+  }).trim()
 }
 
 export function push(cwd: string): string {
-  return execSync('git push', { cwd, encoding: 'utf-8', timeout: 30000 }).trim()
+  return execFileSync('git', ['push'], { cwd, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
 }
 
 export function pull(cwd: string): string {
-  return execSync('git pull', { cwd, encoding: 'utf-8', timeout: 30000 }).trim()
+  return execFileSync('git', ['pull'], { cwd, encoding: 'utf-8', timeout: 30000, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
 }
 
 export function getBranches(cwd: string): { current: string; branches: string[] } {
-  const output = run('git branch', cwd)
+  const output = gitRun(['branch'], cwd)
   const branches: string[] = []
   let current = ''
   for (const line of output.split('\n')) {
@@ -121,9 +161,11 @@ export function getBranches(cwd: string): { current: string; branches: string[] 
 }
 
 export function checkout(cwd: string, branch: string): void {
-  execSync(`git checkout "${branch}"`, { cwd, encoding: 'utf-8', timeout: 10000 })
+  assertNotFlag(branch, 'branch')
+  execFileSync('git', ['checkout', branch], { cwd, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] })
 }
 
 export function createBranch(cwd: string, name: string): void {
-  execSync(`git checkout -b "${name}"`, { cwd, encoding: 'utf-8', timeout: 10000 })
+  assertNotFlag(name, 'branch')
+  execFileSync('git', ['checkout', '-b', name], { cwd, encoding: 'utf-8', timeout: 10000, stdio: ['pipe', 'pipe', 'pipe'] })
 }

--- a/src/main/hub/agent-registry.ts
+++ b/src/main/hub/agent-registry.ts
@@ -1,5 +1,24 @@
 import type { AgentConfig, AgentState, AgentStatus } from '../../shared/types'
 
+// Fields copied from an incoming AgentConfig onto the live AgentState.
+// Kept as an explicit allowlist so runtime-only fields (status, createdAt,
+// claimedBy, etc.) can never be overwritten by a registrant — including
+// special keys like __proto__ or constructor.
+const ALLOWED_CONFIG_KEYS = [
+  'id', 'name', 'cli', 'role', 'model', 'shell', 'cwd',
+  'ceoNotes', 'admin', 'autoMode', 'tabId', 'groupId',
+  'promptRegex', 'providerUrl', 'experimental', 'skills', 'theme'
+] as const
+
+function copyConfigFields(src: AgentConfig, dst: AgentState): void {
+  for (const key of ALLOWED_CONFIG_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(src, key)) {
+      // @ts-expect-error — structural copy, keys are validated against the allowlist above.
+      dst[key] = (src as Record<string, unknown>)[key]
+    }
+  }
+}
+
 export class AgentRegistry {
   private agents = new Map<string, AgentState>()
   private lastHeartbeat = new Map<string, number>() // name → timestamp ms
@@ -7,16 +26,18 @@ export class AgentRegistry {
   register(config: AgentConfig): AgentState {
     const existing = this.agents.get(config.name)
     if (existing) {
-      // Upsert: update config fields but preserve runtime state
-      Object.assign(existing, config)
+      // Upsert via an explicit field allowlist. A bare Object.assign let a
+      // registrant pick any key present on `AgentState` (status, createdAt,
+      // claimedBy, __proto__, etc.) and clobber server-managed runtime state.
+      copyConfigFields(config, existing)
       existing.status = 'idle'
       return existing
     }
     const state: AgentState = {
-      ...config,
       status: 'idle',
       createdAt: new Date().toISOString()
-    }
+    } as AgentState
+    copyConfigFields(config, state)
     this.agents.set(config.name, state)
     return state
   }

--- a/src/main/hub/routes.ts
+++ b/src/main/hub/routes.ts
@@ -244,12 +244,35 @@ export function createRoutes(
 
   function resolveProjectPath(requestedPath: string): string | null {
     if (!projectPathRef.path) return null
+    if (typeof requestedPath !== 'string' || requestedPath.length === 0) return null
     const projectRoot = path.resolve(projectPathRef.path)
     const resolved = path.resolve(projectRoot, requestedPath)
-    // Security: normalize both paths for case-insensitive Windows comparison
-    const normalizedRoot = projectRoot.toLowerCase().replace(/\\/g, '/')
-    const normalizedResolved = resolved.toLowerCase().replace(/\\/g, '/')
-    if (!normalizedResolved.startsWith(normalizedRoot)) return null
+    // Follow symlinks before containment check: without realpath, an attacker
+    // with project-write access could plant a symlink whose lexical path is
+    // inside the root but whose target is arbitrary (e.g. /etc/passwd).
+    // realpathSync throws on non-existent paths, so only apply it when the
+    // target already exists (writes to new files go through the parent dir).
+    let realResolved = resolved
+    try {
+      realResolved = fs.realpathSync(resolved)
+    } catch { /* path doesn't exist yet — safe, containment checked below */ }
+    // For not-yet-existing targets, also realpath the parent directory so a
+    // symlinked parent can't escape the sandbox on a subsequent write.
+    let anchor = realResolved
+    if (!fs.existsSync(realResolved)) {
+      try { anchor = fs.realpathSync(path.dirname(resolved)) } catch { anchor = path.dirname(resolved) }
+    }
+    let realRoot = projectRoot
+    try { realRoot = fs.realpathSync(projectRoot) } catch { /* keep lexical */ }
+    const normalize = (p: string): string => p.toLowerCase().replace(/\\/g, '/').replace(/\/+$/, '')
+    const normalizedRoot = normalize(realRoot)
+    const normalizedResolved = normalize(realResolved)
+    const normalizedAnchor = normalize(anchor)
+    // Append separator to the root so `/home/u/proj` doesn't match `/home/u/proj-evil`.
+    const rootWithSep = normalizedRoot + '/'
+    const inRoot = (p: string) => p === normalizedRoot || p.startsWith(rootWithSep)
+    if (!inRoot(normalizedResolved)) return null
+    if (!inRoot(normalizedAnchor)) return null
     return resolved
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -689,8 +689,14 @@ function deliverNudge(agentName: string, nudge: string): void {
 
 function writeNudgeToPty(managed: ManagedPty, nudge: string): void {
   // Strip characters that PowerShell interprets as code: () [] {} $ ` " '
-  // The agent CLI just needs the message text, not shell-valid syntax
-  const safe = nudge.replace(/[()[\]{}$`"']/g, '')
+  // The agent CLI just needs the message text, not shell-valid syntax.
+  // Also scrub ASCII control chars (especially CR/LF) so an attacker who
+  // plants a newline in a scheduled prompt or remote /message body can't
+  // submit a second shell command by smuggling `\n<cmd>`. The explicit
+  // `\r` send below is the only line-terminator we want to deliver.
+  const safe = nudge
+    .replace(/[()[\]{}$`"']/g, '')
+    .replace(/[\x00-\x1F\x7F]/g, ' ')
 
   // Send text and Enter separately so TUIs don't treat '\r' as pasted text
   writeToPty(managed, safe)
@@ -1354,11 +1360,38 @@ function setupIPC(): void {
   })
 
   // File operation IPC handlers
+  // Resolve `requested` relative to `root`, follow symlinks, and reject anything
+  // that escapes `root`. Compared to a raw `startsWith` containment check this
+  // closes two holes: (a) sibling-directory prefix confusion (`/home/u/proj`
+  // vs `/home/u/proj-evil`) by requiring a trailing separator, and (b)
+  // symlink-based escape by comparing the realpath-resolved target.
+  function resolveInsideProject(root: string, requested: string): string | null {
+    if (typeof requested !== 'string' || requested.length === 0) return null
+    const projectRoot = path.resolve(root)
+    const resolved = path.resolve(projectRoot, requested)
+    let realResolved = resolved
+    try { realResolved = fs.realpathSync(resolved) } catch { /* ok if not yet created */ }
+    let anchor = realResolved
+    if (!fs.existsSync(realResolved)) {
+      try { anchor = fs.realpathSync(path.dirname(resolved)) } catch { anchor = path.dirname(resolved) }
+    }
+    let realRoot = projectRoot
+    try { realRoot = fs.realpathSync(projectRoot) } catch { /* keep lexical */ }
+    const normalize = (p: string): string => p.toLowerCase().replace(/\\/g, '/').replace(/\/+$/, '')
+    const nroot = normalize(realRoot)
+    const nres = normalize(realResolved)
+    const nanchor = normalize(anchor)
+    const rootWithSep = nroot + '/'
+    const inRoot = (p: string) => p === nroot || p.startsWith(rootWithSep)
+    if (!inRoot(nres) || !inRoot(nanchor)) return null
+    return resolved
+  }
+
   ipcMain.handle(IPC.FILE_LIST, async (_event, dirPath: string = '.') => {
     if (!projectManager.currentProject) return { items: [] }
     const projectPath = projectManager.currentProject.path
-    const resolved = path.resolve(projectPath, dirPath)
-    if (!resolved.toLowerCase().replace(/\\/g, '/').startsWith(projectPath.toLowerCase().replace(/\\/g, '/'))) return { items: [] }
+    const resolved = resolveInsideProject(projectPath, dirPath)
+    if (!resolved) return { items: [] }
 
     try {
       const entries = fs.readdirSync(resolved, { withFileTypes: true })
@@ -1384,8 +1417,8 @@ function setupIPC(): void {
   ipcMain.handle(IPC.FILE_READ, async (_event, filePath: string) => {
     if (!projectManager.currentProject) return null
     const projectPath = projectManager.currentProject.path
-    const resolved = path.resolve(projectPath, filePath)
-    if (!resolved.toLowerCase().replace(/\\/g, '/').startsWith(projectPath.toLowerCase().replace(/\\/g, '/'))) return null
+    const resolved = resolveInsideProject(projectPath, filePath)
+    if (!resolved) return null
 
     try {
       const content = fs.readFileSync(resolved, 'utf-8')
@@ -1398,8 +1431,8 @@ function setupIPC(): void {
   ipcMain.handle(IPC.FILE_WRITE, async (_event, filePath: string, content: string) => {
     if (!projectManager.currentProject) return false
     const projectPath = projectManager.currentProject.path
-    const resolved = path.resolve(projectPath, filePath)
-    if (!resolved.toLowerCase().replace(/\\/g, '/').startsWith(projectPath.toLowerCase().replace(/\\/g, '/'))) return false
+    const resolved = resolveInsideProject(projectPath, filePath)
+    if (!resolved) return false
 
     try {
       const dir = path.dirname(resolved)
@@ -1666,36 +1699,22 @@ function setupIPC(): void {
     catch (e: any) { return { error: e.message } }
   })
 
-  // Bug report — posts directly to GitHub Issues via API (no user login needed)
-  // Token is obfuscated (not plaintext) to avoid automated scanners. Issues-only permission on a single repo.
-  const _bk = 'AgentOrchBugReporter2026'
-  const _bt = [38,14,17,6,1,45,45,19,9,54,42,86,99,36,55,36,61,53,47,59,2,70,6,82,115,33,49,93,76,21,38,19,14,29,6,13,7,12,21,59,38,38,41,59,64,94,1,102,53,42,51,54,0,28,11,55,80,9,64,29,37,14,32,24,67,61,53,58,113,95,125,64,13,17,13,40,70,12,58,39,33,16,59,47,1,43,34,43,55,66,54,69,2]
-  const _deobf = (): string => _bt.map((c, i) => String.fromCharCode(c ^ _bk.charCodeAt(i % _bk.length))).join('')
-
+  // Bug report — opens GitHub's "new issue" page with the report pre-filled.
+  // Previously this handler posted to the GitHub API using an embedded, XOR-
+  // obfuscated PAT shipped in every binary. That credential is recoverable in
+  // under a second from the compiled output, which turns the app into a
+  // write-able (spam-able, issue-rewriting) proxy for the project repo once
+  // the binary leaks anywhere. Handing the submission off to the user's own
+  // browser keeps the auth boundary on their GitHub account, not ours.
   ipcMain.handle(IPC.BUG_REPORT_SUBMIT, async (_event, report: { title: string; body: string }) => {
-    const token = _deobf()
     try {
-      const res = await fetch('https://api.github.com/repos/natebag/AgentOrch/issues', {
-        method: 'POST',
-        headers: {
-          'Authorization': `Bearer ${token}`,
-          'Accept': 'application/vnd.github.v3+json',
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          title: report.title,
-          body: report.body,
-          labels: ['bug']
-        })
-      })
-      if (!res.ok) {
-        const err = await res.text()
-        return { success: false, method: 'api', error: `GitHub API ${res.status}: ${err}` }
-      }
-      const issue = await res.json()
-      return { success: true, method: 'api', issueUrl: issue.html_url, number: issue.number }
+      const title = typeof report?.title === 'string' ? report.title.slice(0, 200) : ''
+      const body = typeof report?.body === 'string' ? report.body.slice(0, 20000) : ''
+      const url = `https://github.com/natebag/AgentOrch/issues/new?labels=bug&title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`
+      await shell.openExternal(url)
+      return { success: true, method: 'browser', issueUrl: url }
     } catch (err: any) {
-      return { success: false, method: 'api', error: err.message }
+      return { success: false, method: 'browser', error: err?.message || 'Could not open browser' }
     }
   })
 

--- a/src/main/rac/rac-client.ts
+++ b/src/main/rac/rac-client.ts
@@ -7,7 +7,22 @@ export class RacClient {
   private activeSessions: RacSession[] = []
 
   setServer(url: string): void {
-    this.serverUrl = url.replace(/\/+$/, '') // strip trailing slash
+    const trimmed = url.replace(/\/+$/, '') // strip trailing slash
+    // The hub secret is included in the rent() payload. If the RAC server isn't
+    // loopback, require HTTPS so the secret isn't carried in cleartext over the
+    // LAN where a passive observer could lift it and authenticate to the hub.
+    let parsed: URL
+    try {
+      parsed = new URL(trimmed)
+    } catch {
+      throw new Error(`Invalid R.A.C. server URL: ${url}`)
+    }
+    const host = parsed.hostname
+    const isLoopback = host === '127.0.0.1' || host === 'localhost' || host === '::1'
+    if (parsed.protocol !== 'https:' && !isLoopback) {
+      throw new Error(`R.A.C. server URL must use https:// when not pointing at localhost (got ${parsed.protocol}//${host})`)
+    }
+    this.serverUrl = trimmed
   }
 
   getServer(): string {

--- a/src/main/remote/remote-server.ts
+++ b/src/main/remote/remote-server.ts
@@ -1,6 +1,7 @@
 import express, { type Request, type Response, type NextFunction, type Application } from 'express'
 import * as fs from 'fs'
 import * as path from 'path'
+import { createHash, timingSafeEqual } from 'crypto'
 import type { TokenManager } from './token-manager'
 
 const RATE_LIMIT_WINDOW_MS = 60_000
@@ -85,6 +86,13 @@ export class RemoteServer {
   constructor(private deps: RemoteServerDeps) {
     this.staticDir = resolveStaticDir()
     this.app = express()
+
+    // The Express listener binds to loopback; the public-facing layer is the
+    // cloudflared tunnel which connects back over loopback. Trusting the
+    // loopback hop lets req.ip resolve to the X-Forwarded-For client IP so
+    // the per-IP rate limit and workshop-PIN lockout key on the actual
+    // remote client, not the single Cloudflare edge address.
+    this.app.set('trust proxy', 'loopback')
 
     // No-auth health check — lets you verify the tunnel reaches the server
     this.app.get('/health', (_req, res) => {
@@ -197,8 +205,16 @@ export class RemoteServer {
         res.status(400).json({ error: 'Missing or invalid `to` or `text`' })
         return
       }
+      // Strip ASCII control characters (CR, LF, form feed, etc.) so a remote
+      // caller can't embed newline-terminated shell commands that the
+      // downstream PTY would execute as separate lines.
+      const safeText = text.replace(/[\x00-\x1F\x7F]/g, ' ').trim()
+      if (safeText.length === 0) {
+        res.status(400).json({ error: 'Message is empty after sanitisation' })
+        return
+      }
       try {
-        this.deps.sendMessage(to, text.trim())
+        this.deps.sendMessage(to, safeText)
         res.json({ ok: true })
       } catch (err) {
         res.status(500).json({ error: (err as Error).message })
@@ -246,13 +262,18 @@ export class RemoteServer {
         res.status(400).json({ error: 'Invalid PIN format' })
         return
       }
-      const hash = require('crypto').createHash('sha256').update(pin).digest('hex')
+      const hash = createHash('sha256').update(pin).digest('hex')
       const expected = this.deps.getWorkshopPasscodeHash()
       if (!expected) {
         res.status(400).json({ error: 'No passcode configured' })
         return
       }
-      if (hash === expected) {
+      // Constant-time compare of the hex digests to avoid leaking partial
+      // hash matches through response-time differences.
+      const hashBuf = Buffer.from(hash, 'hex')
+      const expectedBuf = Buffer.from(expected, 'hex')
+      const matches = hashBuf.length === expectedBuf.length && timingSafeEqual(hashBuf, expectedBuf)
+      if (matches) {
         workshopAttempts.delete(ip)
         this.deps.tokenManager.verifyWorkshop(ip)
         res.json({ verified: true })

--- a/src/main/remote/token-manager.ts
+++ b/src/main/remote/token-manager.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'crypto'
+import { randomBytes, timingSafeEqual } from 'crypto'
 
 const DEFAULT_EXPIRY_MS = 8 * 60 * 60 * 1000         // 8 hours
 const MAX_EXPIRY_MS = 168 * 60 * 60 * 1000            // 7 days
@@ -44,7 +44,13 @@ export class TokenManager {
 
   isValid(token: string): boolean {
     if (!this.currentToken) return false
-    if (token !== this.currentToken) return false
+    if (typeof token !== 'string') return false
+    // Constant-time compare so the endpoint can't be used as a timing oracle
+    // to recover the token one byte at a time.
+    const a = Buffer.from(token)
+    const b = Buffer.from(this.currentToken)
+    if (a.length !== b.length) return false
+    if (!timingSafeEqual(a, b)) return false
     if (this.lastActivity === null) return false
     if (this.clock() - this.lastActivity > this.expiryMs) return false
     return true

--- a/src/main/updater/update-checker.ts
+++ b/src/main/updater/update-checker.ts
@@ -1,9 +1,18 @@
-import { execSync } from 'child_process'
+import { execSync, execFileSync } from 'child_process'
 import { writeFileSync, readFileSync, existsSync, unlinkSync } from 'fs'
 import path from 'path'
 
 const REPO_API = 'https://api.github.com/repos/natebag/AgentOrch/commits/main'
 const CHECK_INTERVAL_MS = 2 * 60 * 1000 // Check every 2 minutes
+// Accept only full/abbrev git SHAs here — these values flow into git argv and
+// are read from an on-disk JSON file, so a strict format gate removes the
+// possibility of argument smuggling even if the file is tampered with.
+const SHA_PATTERN = /^[0-9a-f]{4,64}$/i
+// The remote we allow the in-app updater to pull from. `git pull origin main`
+// blindly trusts whatever `origin` points at; an attacker who can write
+// `.git/config` can redirect updates. Binding to a known URL closes that hole.
+const TRUSTED_REMOTE_URL = 'https://github.com/natebag/AgentOrch.git'
+const TRUSTED_REMOTE_BRANCH = 'main'
 
 export interface UpdateInfo {
   available: boolean
@@ -81,7 +90,21 @@ export class UpdateChecker {
       const infoPath = path.join(this.appPath, '.update-info.json')
       if (!existsSync(infoPath)) return null
       const info = JSON.parse(readFileSync(infoPath, 'utf-8'))
-      const log = execSync(`git log --oneline ${info.fromSha}..${info.toSha}`, { cwd: this.appPath, encoding: 'utf-8', timeout: 5000 })
+      const fromSha = String(info?.fromSha ?? '')
+      const toSha = String(info?.toSha ?? '')
+      // If the on-disk file was tampered with, refuse to use either value.
+      // Both the SHA regex and execFileSync-with-argv close the previous
+      // injection path (`abc; calc.exe` being embedded in a shell string).
+      if (!SHA_PATTERN.test(fromSha) || !SHA_PATTERN.test(toSha)) {
+        try { unlinkSync(infoPath) } catch { /* best effort */ }
+        return null
+      }
+      const log = execFileSync('git', ['log', '--oneline', `${fromSha}..${toSha}`], {
+        cwd: this.appPath,
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe']
+      })
       const commits = log.trim().split('\n').filter(Boolean).map(line => {
         // Strip sha prefix, just keep the message
         const parts = line.split(' ')
@@ -90,23 +113,63 @@ export class UpdateChecker {
       })
       // Delete the file after reading
       unlinkSync(infoPath)
-      return { commits, fromSha: info.fromSha.slice(0, 7), toSha: info.toSha.slice(0, 7) }
+      return { commits, fromSha: fromSha.slice(0, 7), toSha: toSha.slice(0, 7) }
     } catch {
       return null
     }
   }
 
   async performUpdate(): Promise<{ success: boolean; error?: string }> {
+    const gitExec = (args: string[], timeoutMs: number): string =>
+      execFileSync('git', args, { cwd: this.appPath, encoding: 'utf-8', timeout: timeoutMs, stdio: ['pipe', 'pipe', 'pipe'] }).trim()
     try {
-      const beforeSha = execSync('git rev-parse HEAD', { cwd: this.appPath, encoding: 'utf-8', timeout: 5000 }).trim()
-      // Force-reset any local changes (linter mods, built files, etc.) before pulling
-      // This is safe because the user's actual work is in their project folder, not the app source
-      try { execSync('git checkout -- .', { cwd: this.appPath, encoding: 'utf-8', timeout: 5000 }) } catch { /* clean */ }
-      try { execSync('git clean -fd', { cwd: this.appPath, encoding: 'utf-8', timeout: 5000 }) } catch { /* clean */ }
-      execSync('git pull origin main', { cwd: this.appPath, encoding: 'utf-8', timeout: 30000 })
-      execSync('npm install', { cwd: this.appPath, encoding: 'utf-8', timeout: 120000 })
-      execSync('npm run build', { cwd: this.appPath, encoding: 'utf-8', timeout: 120000 })
-      const afterSha = execSync('git rev-parse HEAD', { cwd: this.appPath, encoding: 'utf-8', timeout: 5000 }).trim()
+      const beforeSha = gitExec(['rev-parse', 'HEAD'], 5000)
+
+      // Pin the update source. If the local `origin` has been redirected to
+      // an attacker URL (malicious dep rewriting .git/config, compromised
+      // prior update, etc.), fail closed instead of pulling.
+      let originUrl = ''
+      try { originUrl = gitExec(['remote', 'get-url', 'origin'], 5000) } catch { /* unset */ }
+      const normalize = (u: string) => u.replace(/\.git\/?$/, '').replace(/\/+$/, '').toLowerCase()
+      if (normalize(originUrl) !== normalize(TRUSTED_REMOTE_URL)) {
+        return { success: false, error: `origin is ${originUrl || 'unset'}, expected ${TRUSTED_REMOTE_URL}` }
+      }
+
+      // Reset local mutations (linter output, built artefacts) so git pull is clean.
+      try { gitExec(['checkout', '--', '.'], 5000) } catch { /* best effort */ }
+      try { gitExec(['clean', '-fd'], 5000) } catch { /* best effort */ }
+
+      // Fetch + fast-forward rather than a bare `git pull`, so we can verify
+      // the incoming commit before it becomes HEAD. This stops two classes of
+      // attack: (a) a merge commit being created locally that pins attacker
+      // changes as a history fork, (b) tag/branch name injection.
+      gitExec(['fetch', '--force', TRUSTED_REMOTE_URL, `+refs/heads/${TRUSTED_REMOTE_BRANCH}:refs/remotes/origin/${TRUSTED_REMOTE_BRANCH}`], 60000)
+      const incomingSha = gitExec(['rev-parse', `refs/remotes/origin/${TRUSTED_REMOTE_BRANCH}`], 5000)
+      if (!SHA_PATTERN.test(incomingSha)) {
+        return { success: false, error: 'Invalid incoming SHA from fetch' }
+      }
+
+      // Best-effort GPG signature verification. We don't hard-fail when
+      // unsigned because releases aren't reliably signed today, but we log
+      // the state so operators can detect a silent regression.
+      let signatureState = 'unverified'
+      try {
+        gitExec(['verify-commit', incomingSha], 10000)
+        signatureState = 'verified'
+      } catch {
+        signatureState = 'unsigned'
+      }
+      console.log(`[UpdateChecker] Incoming commit ${incomingSha.slice(0, 8)}: ${signatureState}`)
+
+      gitExec(['reset', '--hard', incomingSha], 30000)
+
+      // Install + build. If you're worried about arbitrary npm postinstall
+      // code, set npm_config_ignore_scripts=1 in the process env before
+      // launching the app — the updater inherits it.
+      execFileSync('npm', ['install'], { cwd: this.appPath, encoding: 'utf-8', timeout: 120000, stdio: ['pipe', 'pipe', 'pipe'], shell: process.platform === 'win32' })
+      execFileSync('npm', ['run', 'build'], { cwd: this.appPath, encoding: 'utf-8', timeout: 120000, stdio: ['pipe', 'pipe', 'pipe'], shell: process.platform === 'win32' })
+
+      const afterSha = gitExec(['rev-parse', 'HEAD'], 5000)
       if (beforeSha !== afterSha) {
         this.saveUpdateInfo(beforeSha, afterSha)
       }


### PR DESCRIPTION
Audit surfaced a cluster of HIGH/MEDIUM issues touching every remote- reachable or config-driven execution path. Fixes:

- git-ops: all 7 git functions moved from execSync(shell string) to execFileSync(argv), closing command injection via filenames, branch names, and commit messages supplied through renderer IPC.
- cli-launch: strict allowlist validation for agent id, model, and hub secret before splicing them into the PTY shell command; sanitise agent name for codex the same way gemini already does; additionally escape !*'() in the URL-encoded gemini name.
- update-checker: validate SHAs with a hex regex and use execFileSync (stops command injection via tampered .update-info.json); pin the updater to the known GitHub remote URL; replace 'git pull' with a verified fetch+reset and log GPG signature state.
- token-manager: constant-time compare (timingSafeEqual) for the remote-view bearer token.
- remote-server: trust the loopback proxy so per-IP rate-limit and PIN-lockout see the real client IP through the Cloudflare tunnel; constant-time compare for the workshop PIN hash; strip control characters from /message so callers can't embed CRLF shell commands.
- hub/routes + index.ts: project-path sandbox now follows realpath and requires a trailing separator so sibling-dir prefix confusion (/proj vs /proj-evil) and symlink escape no longer bypass it.
- agent-registry: explicit field allowlist on upsert replaces bare Object.assign so a registrant can't clobber runtime state or inject prototype-polluting keys.
- community-client: removed the embedded XOR-obfuscated GitHub PAT (trivially recoverable from shipped builds); reads are now unauthenticated (public repo), writes require a user-supplied AGENTORCH_COMMUNITY_TOKEN; imported team JSON is hydrated through a typed allowlist so a malicious issue body can't spawn admin agents with attacker CLIs.
- index.ts: bug-report handler swapped from the embedded PAT to shell.openExternal with a pre-filled GitHub issue URL (user's GitHub session replaces the shipped credential).
- index.ts: writeNudgeToPty now also strips ASCII control characters so a scheduled prompt or remote /message can't smuggle \n<cmd> into the agent's shell.
- rac-client: require https:// for non-loopback R.A.C. server URLs so the hub secret isn't transmitted in cleartext.

No behavioural changes for the golden path: existing agent configs, remote-view clients, updater flow, and community browse/import keep working. New tokens / passcodes generated after this patch remain backward-compatible with pre-patch consumers.