### PR TITLE
fix(sketchpad): render photo pages on demand instead of 409ing; surface rasterizer errors

### DIFF
--- a/src/main/hub/routes.ts
+++ b/src/main/hub/routes.ts
@@ -41,6 +41,9 @@ export interface ScheduleBridge {
 export interface BoardBridge {
   listPages: () => { page: number; elementCount: number; strokeCount: number }[]
   renderPath: (pageNumber: number) => string | null // null=out-of-range, ''=no render yet, else abs path
+  // Optional: headless re-render of a page (wired by index.ts). Lets the
+  // render route produce a fresh PNG instead of 409ing when none exists.
+  requestRender?: (pageNumber: number) => Promise<{ ok: boolean; error?: string }>
 }
 
 export function createRoutes(
@@ -474,14 +477,32 @@ export function createRoutes(
     res.json(b ? b.listPages() : [])
   })
 
-  router.get('/board/pages/:n/render', (req: Request, res: Response) => {
+  router.get('/board/pages/:n/render', async (req: Request, res: Response) => {
     const b = getBoardBridge?.()
     if (!b) { res.status(503).json({ error: 'Board unavailable' }); return }
     const n = parseInt(req.params.n, 10)
     if (!Number.isInteger(n) || n <= 0) { res.status(400).json({ error: 'invalid page number' }); return }
-    const p = b.renderPath(n)
+    let p = b.renderPath(n)
     if (p === null) { res.status(404).json({ error: `No page ${n}` }); return }
-    if (p === '') { res.status(409).json({ error: `Page ${n} has no render yet — open it in the Workboard first` }); return }
+    if (p === '' && b.requestRender) {
+      // No PNG on disk (page never opened / render previously failed) —
+      // trigger a fresh headless render and wait for it instead of 409ing.
+      let result: { ok: boolean; error?: string }
+      try {
+        result = await b.requestRender(n)
+      } catch (err: any) {
+        result = { ok: false, error: err?.message || String(err) }
+      }
+      p = b.renderPath(n) ?? ''
+      if (p === '') {
+        const reason = result.error ? `: ${result.error}` : ''
+        res.status(409).json({ error: `Page ${n} could not be rendered${reason}. Open it in the Workboard to refresh it manually.` })
+        return
+      }
+    } else if (p === '') {
+      res.status(409).json({ error: `Page ${n} has no render yet — open it in the Workboard first` })
+      return
+    }
     res.json({ path: p, page: n })
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1673,7 +1673,20 @@ async function openProject(projectPath: string): Promise<void> {
           resolve({ ok, error })
         }
         ipcMain.on(IPC.BOARD_RENDER_RESULT, handler)
-        win.webContents.send(IPC.BOARD_RENDER_REQUEST, { pageId: page.id, requestId })
+        // Guarded send: the window can be torn down between the early
+        // isDestroyed() check and this point, and sending to a destroyed
+        // webContents throws. Fail the request cleanly (no leaked listener,
+        // no 15s dangling timer) instead of rejecting.
+        try {
+          if (win.isDestroyed() || win.webContents.isDestroyed()) {
+            throw new Error('Main window destroyed before render request could be sent')
+          }
+          win.webContents.send(IPC.BOARD_RENDER_REQUEST, { pageId: page.id, requestId })
+        } catch (err) {
+          clearTimeout(timer)
+          ipcMain.removeListener(IPC.BOARD_RENDER_RESULT, handler)
+          resolve({ ok: false, error: err instanceof Error ? err.message : String(err) })
+        }
       })
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -26,7 +26,7 @@ import { canAgentCancelSchedule } from './scheduler/scheduler-helpers'
 import type { Server as HttpServer } from 'http'
 import * as https from 'https'
 import * as httpProto from 'http'
-import { createHash } from 'crypto'
+import { createHash, randomUUID } from 'crypto'
 import { spawn as spawnChildProcess } from 'child_process'
 import { v4 as uuidv4 } from 'uuid'
 import { TokenManager } from './remote/token-manager'
@@ -1651,6 +1651,30 @@ async function openProject(projectPath: string): Promise<void> {
       const rp = renderPathForPage(root, boardStore.listPages(), n)
       if (rp === null) return null
       return fs.existsSync(rp) ? rp : ''
+    },
+    // Ask the renderer's board-render-service to (re)render page n headlessly.
+    // Resolves once the renderer reports back (or after a 15s timeout) so the
+    // hub route can serve a fresh PNG instead of 409ing on never-opened pages.
+    requestRender: (n) => {
+      const page = (boardStore?.listPages() ?? []).find(p => p.orderIndex === n)
+      const win = mainWindow
+      if (!page) return Promise.resolve({ ok: false, error: `No page ${n}` })
+      if (!win || win.isDestroyed()) return Promise.resolve({ ok: false, error: 'Main window unavailable' })
+      const requestId = randomUUID()
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          ipcMain.removeListener(IPC.BOARD_RENDER_RESULT, handler)
+          resolve({ ok: false, error: 'Render timed out after 15s' })
+        }, 15_000)
+        const handler = (_e: Electron.IpcMainEvent, rid: string, ok: boolean, error?: string): void => {
+          if (rid !== requestId) return
+          clearTimeout(timer)
+          ipcMain.removeListener(IPC.BOARD_RENDER_RESULT, handler)
+          resolve({ ok, error })
+        }
+        ipcMain.on(IPC.BOARD_RENDER_RESULT, handler)
+        win.webContents.send(IPC.BOARD_RENDER_REQUEST, { pageId: page.id, requestId })
+      })
     }
   }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -312,4 +312,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   boardReadImage: (file: string) => ipcRenderer.invoke(IPC.BOARD_READ_IMAGE, file),
   getBoardAppearance: () => ipcRenderer.invoke(IPC.BOARD_APPEARANCE_GET),
   setBoardAppearance: (value: { bgColor: string; showGrid: boolean; gridColor: string }) => ipcRenderer.invoke(IPC.BOARD_APPEARANCE_SET, value),
+  // Headless render requests (main -> renderer -> main); see board-render-service.ts
+  onBoardRenderRequest: (cb: (req: { pageId: string; requestId: string }) => void) => {
+    const handler = (_e: unknown, req: { pageId: string; requestId: string }) => cb(req)
+    ipcRenderer.on(IPC.BOARD_RENDER_REQUEST, handler)
+    return () => ipcRenderer.removeListener(IPC.BOARD_RENDER_REQUEST, handler)
+  },
+  boardRenderResult: (requestId: string, ok: boolean, error?: string) =>
+    ipcRenderer.send(IPC.BOARD_RENDER_RESULT, requestId, ok, error),
 })

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -14,6 +14,7 @@ import { WhatsNewDialog } from './components/WhatsNewDialog'
 import { EditAgentDialog } from './components/EditAgentDialog'
 import type { AgentConfig, AgentGroup, RecentProject, WindowPosition, CanvasState, WorkspaceTab, TeamProposal, InboxMessage } from '../shared/types'
 import { TeamProposalDialog } from './components/TeamProposalDialog'
+import { initBoardRenderService } from './board-render-service'
 
 declare const electronAPI: {
   getProject: () => Promise<RecentProject | null>
@@ -60,6 +61,10 @@ export function App(): React.ReactElement {
     setZoom, setPan, updateWindowPosition, updateWindowSize, zoomToFit
   } = useWindowManager()
   const { agents, spawnAgent, killAgent, getStatusColor } = useAgents()
+
+  // Headless Sketchpad render service: lets the hub render any board page on
+  // demand (e.g. for agent photo review) even when the Workboard is closed.
+  useEffect(() => { initBoardRenderService() }, [])
 
   // Filter windows to only those belonging to the active tab
   const tabWindows = windows.filter(w => w.tabId === activeTabId)

--- a/src/renderer/board-render-service.ts
+++ b/src/renderer/board-render-service.ts
@@ -1,0 +1,202 @@
+import type { BoardAppearance, BoardElement, BoardPage } from '../shared/types'
+import { renderStroke } from './hooks/useBoardDrawing'
+
+/**
+ * Headless Sketchpad page renderer.
+ *
+ * The live render path (BoardPageCanvas -> rasterizeNode) only runs while a
+ * page is open in the Workboard, so any page that was never (re)visited has no
+ * render PNG and agents got a 409 from /board/pages/:n/render. This service
+ * lets the main process request a render of ANY page at any time: it paints
+ * the page onto an offscreen canvas (same stroke logic as the drawing overlay,
+ * minimal-but-faithful element painting) and saves it via the existing
+ * BOARD_SAVE_RENDER IPC.
+ */
+
+const MIN_W = 800
+const MIN_H = 600
+const MAX_DIM = 4000
+const PAD = 40
+
+interface Bounds { x: number; y: number; w: number; h: number }
+
+/** Union of the default viewport at origin and all element/stroke extents. */
+export function computePageBounds(page: BoardPage): Bounds {
+  let minX = 0
+  let minY = 0
+  let maxX = MIN_W
+  let maxY = MIN_H
+  for (const el of page.elements) {
+    minX = Math.min(minX, el.x - PAD)
+    minY = Math.min(minY, el.y - PAD)
+    maxX = Math.max(maxX, el.x + el.w + PAD)
+    maxY = Math.max(maxY, el.y + el.h + PAD)
+  }
+  for (const s of page.strokes) {
+    const r = s.width / 2 + PAD
+    for (const p of s.points) {
+      minX = Math.min(minX, p.x - r)
+      minY = Math.min(minY, p.y - r)
+      maxX = Math.max(maxX, p.x + r)
+      maxY = Math.max(maxY, p.y + r)
+    }
+  }
+  const w = Math.min(maxX - minX, MAX_DIM)
+  const h = Math.min(maxY - minY, MAX_DIM)
+  return { x: minX, y: minY, w, h }
+}
+
+/** Basic word wrap honoring explicit newlines. */
+function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string[] {
+  const lines: string[] = []
+  for (const para of text.split('\n')) {
+    let line = ''
+    for (const word of para.split(' ')) {
+      const candidate = line ? `${line} ${word}` : word
+      if (line && ctx.measureText(candidate).width > maxWidth) {
+        lines.push(line)
+        line = word
+      } else {
+        line = candidate
+      }
+    }
+    lines.push(line)
+  }
+  return lines
+}
+
+function drawWrappedText(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  maxHeight: number,
+  fontSize: number,
+  color: string
+): void {
+  ctx.font = `${fontSize}px sans-serif`
+  ctx.fillStyle = color
+  ctx.textBaseline = 'top'
+  const lineHeight = fontSize * 1.5
+  const lines = wrapText(ctx, text, maxWidth)
+  for (let i = 0; i < lines.length; i++) {
+    const ly = y + i * lineHeight
+    if (ly + lineHeight > y + maxHeight) break
+    ctx.fillText(lines[i], x, ly)
+  }
+}
+
+function roundedRectPath(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+  ctx.beginPath()
+  ctx.moveTo(x + r, y)
+  ctx.arcTo(x + w, y, x + w, y + h, r)
+  ctx.arcTo(x + w, y + h, x, y + h, r)
+  ctx.arcTo(x, y + h, x, y, r)
+  ctx.arcTo(x, y, x + w, y, r)
+  ctx.closePath()
+}
+
+/** Load a board image (bare filename via IPC, or a data: URL) as an <img>. */
+async function loadBoardImage(file: string): Promise<HTMLImageElement | null> {
+  const src = file.startsWith('data:') ? file : await window.electronAPI.boardReadImage(file)
+  if (!src) return null
+  const img = new Image()
+  img.src = src
+  try {
+    await img.decode()
+  } catch (err) {
+    console.error(`[board-render-service] image decode failed for "${file.slice(0, 64)}":`, err)
+    return null
+  }
+  return img
+}
+
+async function drawElement(ctx: CanvasRenderingContext2D, el: BoardElement, ox: number, oy: number): Promise<void> {
+  const x = el.x + ox
+  const y = el.y + oy
+  if (el.type === 'note') {
+    // Mirror BoardElementView's note: colored rounded card + dark 13px text, 8px padding
+    roundedRectPath(ctx, x, y, el.w, el.h, 6)
+    ctx.fillStyle = el.color
+    ctx.fill()
+    drawWrappedText(ctx, el.text, x + 8, y + 8, el.w - 16, el.h - 16, 13, '#111')
+  } else if (el.type === 'text') {
+    // Mirror BoardElementView's text: light text, 4px padding
+    drawWrappedText(ctx, el.text, x + 4, y + 4, el.w - 8, el.h - 8, el.fontSize, '#ddd')
+  } else {
+    const img = await loadBoardImage(el.file)
+    if (!img) return // broken image degrades that element, not the page
+    // object-fit: contain, centered (same as the live <img> styling)
+    const scale = Math.min(el.w / img.naturalWidth, el.h / img.naturalHeight)
+    const dw = img.naturalWidth * scale
+    const dh = img.naturalHeight * scale
+    ctx.drawImage(img, x + (el.w - dw) / 2, y + (el.h - dh) / 2, dw, dh)
+  }
+}
+
+/** Render a full board page to a base64 PNG (no data: prefix). */
+export async function renderPageToPngBase64(page: BoardPage, appearance: BoardAppearance): Promise<string> {
+  const bounds = computePageBounds(page)
+  const canvas = document.createElement('canvas')
+  canvas.width = Math.round(bounds.w)
+  canvas.height = Math.round(bounds.h)
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Could not acquire 2d canvas context')
+
+  // Background (+ optional grid, 40px cells like the live board)
+  ctx.fillStyle = appearance.bgColor
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+  if (appearance.showGrid) {
+    ctx.strokeStyle = appearance.gridColor
+    ctx.lineWidth = 1
+    for (let gx = -(bounds.x % 40); gx < canvas.width; gx += 40) {
+      ctx.beginPath(); ctx.moveTo(gx, 0); ctx.lineTo(gx, canvas.height); ctx.stroke()
+    }
+    for (let gy = -(bounds.y % 40); gy < canvas.height; gy += 40) {
+      ctx.beginPath(); ctx.moveTo(0, gy); ctx.lineTo(canvas.width, gy); ctx.stroke()
+    }
+  }
+
+  // Elements in z order, then strokes on top (the live board layers the
+  // drawing canvas above the elements layer).
+  const sorted = [...page.elements].sort((a, b) => a.z - b.z)
+  for (const el of sorted) {
+    await drawElement(ctx, el, -bounds.x, -bounds.y)
+  }
+  for (const s of page.strokes) {
+    renderStroke(ctx, s, 1, { x: -bounds.x, y: -bounds.y })
+  }
+
+  const dataUrl = canvas.toDataURL('image/png')
+  const comma = dataUrl.indexOf(',')
+  if (comma < 0) throw new Error('canvas.toDataURL returned no data')
+  return dataUrl.slice(comma + 1)
+}
+
+let initialized = false
+
+/**
+ * Subscribe to main-process render requests. Mounted once from App so renders
+ * work even when the Workboard panel is closed.
+ */
+export function initBoardRenderService(): void {
+  if (initialized) return
+  initialized = true
+  console.log('[board-render-service] initialized')
+  window.electronAPI.onBoardRenderRequest(async ({ pageId, requestId }) => {
+    console.log(`[board-render-service] render request for page ${pageId}`)
+    try {
+      const pages = await window.electronAPI.boardListPages()
+      const page = pages.find((p) => p.id === pageId)
+      if (!page) throw new Error(`Board page ${pageId} not found`)
+      const appearance = await window.electronAPI.getBoardAppearance()
+      const b64 = await renderPageToPngBase64(page, appearance)
+      await window.electronAPI.boardSaveRender(page.id, b64)
+      window.electronAPI.boardRenderResult(requestId, true)
+    } catch (err) {
+      console.error('[board-render-service] render request failed:', err)
+      window.electronAPI.boardRenderResult(requestId, false, err instanceof Error ? err.message : String(err))
+    }
+  })
+}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -147,6 +147,8 @@ declare global {
       boardReadImage: (file: string) => Promise<string | null>
       getBoardAppearance: () => Promise<import('../shared/types').BoardAppearance>
       setBoardAppearance: (value: import('../shared/types').BoardAppearance) => Promise<import('../shared/types').BoardAppearance>
+      onBoardRenderRequest: (cb: (req: { pageId: string; requestId: string }) => void) => () => void
+      boardRenderResult: (requestId: string, ok: boolean, error?: string) => void
     }
   }
 }

--- a/src/renderer/hooks/useBoardDrawing.ts
+++ b/src/renderer/hooks/useBoardDrawing.ts
@@ -61,7 +61,9 @@ function drawArrowhead(
   ctx.stroke()
 }
 
-function renderStroke(
+// Exported so the headless page renderer (board-render-service) paints strokes
+// with exactly the same logic as the live drawing overlay.
+export function renderStroke(
   ctx: CanvasRenderingContext2D,
   stroke: BoardStroke,
   zoom: number,

--- a/src/renderer/hooks/useBoardRasterizer.ts
+++ b/src/renderer/hooks/useBoardRasterizer.ts
@@ -1,12 +1,30 @@
 import { toPng } from 'html-to-image'
 
+/**
+ * Wait for every <img> inside the node to finish decoding so toPng captures
+ * pixels, not half-loaded placeholders. Per-image failures are tolerated —
+ * a broken image should degrade that one element, not kill the whole render.
+ */
+export async function waitForImages(node: HTMLElement): Promise<void> {
+  const imgs = Array.from(node.querySelectorAll('img'))
+  await Promise.all(imgs.map((img) => img.decode().catch(() => {})))
+}
+
 /** Render a DOM node to a base64 PNG (no data: prefix), or null on failure. */
 export async function rasterizeNode(node: HTMLElement, bgColor = '#101010'): Promise<string | null> {
   try {
-    const dataUrl = await toPng(node, { backgroundColor: bgColor, cacheBust: true, pixelRatio: 1 })
+    await waitForImages(node)
+    // cacheBust is intentionally OFF: board images are data: URLs (cache-bust
+    // queries are useless for them) and busting appends ?<timestamp> to any
+    // fetched resource, defeating html-to-image's internal cache.
+    const dataUrl = await toPng(node, { backgroundColor: bgColor, cacheBust: false, pixelRatio: 1 })
     const comma = dataUrl.indexOf(',')
     return comma >= 0 ? dataUrl.slice(comma + 1) : null
-  } catch {
+  } catch (err) {
+    // Surface the real cause (this used to be a silent `catch { return null }`,
+    // which made photo-page render failures undiagnosable). Callers still get
+    // null and degrade gracefully.
+    console.error('[rasterizeNode] board page rasterization failed:', err)
     return null
   }
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -295,6 +295,8 @@ export const IPC = {
   BOARD_READ_IMAGE: 'board:read-image',
   BOARD_APPEARANCE_GET: 'board:appearance-get',
   BOARD_APPEARANCE_SET: 'board:appearance-set',
+  BOARD_RENDER_REQUEST: 'board:render-request',
+  BOARD_RENDER_RESULT: 'board:render-result',
 } as const
 
 export interface Skill {

--- a/tests/unit/board-rasterizer.test.ts
+++ b/tests/unit/board-rasterizer.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock html-to-image so the rasterizer can be exercised in the node test env
+// (real toPng needs a layout engine; its behavior is not under test here).
+const toPngMock = vi.fn()
+vi.mock('html-to-image', () => ({ toPng: (...args: unknown[]) => toPngMock(...args) }))
+
+import { rasterizeNode, waitForImages } from '../../src/renderer/hooks/useBoardRasterizer'
+import { computePageBounds } from '../../src/renderer/board-render-service'
+import type { BoardPage } from '../../src/shared/types'
+
+/** Minimal stand-in for a capture node containing <img> elements. */
+function makeNode(imgs: Array<{ decode: () => Promise<void> }>): HTMLElement {
+  return { querySelectorAll: vi.fn(() => imgs) } as unknown as HTMLElement
+}
+
+beforeEach(() => {
+  toPngMock.mockReset()
+})
+
+describe('waitForImages', () => {
+  it('awaits decode() on every image element', async () => {
+    const decode1 = vi.fn(() => Promise.resolve())
+    const decode2 = vi.fn(() => Promise.resolve())
+    await waitForImages(makeNode([{ decode: decode1 }, { decode: decode2 }]))
+    expect(decode1).toHaveBeenCalledTimes(1)
+    expect(decode2).toHaveBeenCalledTimes(1)
+  })
+
+  it('tolerates a failing decode (broken image must not kill the render)', async () => {
+    const bad = vi.fn(() => Promise.reject(new Error('EncodingError')))
+    await expect(waitForImages(makeNode([{ decode: bad }]))).resolves.toBeUndefined()
+  })
+})
+
+describe('rasterizeNode', () => {
+  it('renders a node with an image element: waits for decode, returns bare base64', async () => {
+    const decode = vi.fn(() => Promise.resolve())
+    const node = makeNode([{ decode }])
+    toPngMock.mockResolvedValue('data:image/png;base64,AAAABBBB')
+
+    const b64 = await rasterizeNode(node, '#101010')
+
+    expect(decode).toHaveBeenCalled()
+    expect(b64).toBe('AAAABBBB')
+  })
+
+  it('calls toPng WITHOUT cacheBust (data-URL images must not be cache-busted)', async () => {
+    toPngMock.mockResolvedValue('data:image/png;base64,XYZ')
+
+    await rasterizeNode(makeNode([]), '#222222')
+
+    expect(toPngMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ cacheBust: false, backgroundColor: '#222222', pixelRatio: 1 })
+    )
+  })
+
+  it('logs the real cause and returns null when toPng throws (no more silent catch)', async () => {
+    const err = new Error('SecurityError: tainted canvas')
+    toPngMock.mockRejectedValue(err)
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const b64 = await rasterizeNode(makeNode([]))
+
+    expect(b64).toBeNull()
+    expect(spy).toHaveBeenCalledWith('[rasterizeNode] board page rasterization failed:', err)
+    spy.mockRestore()
+  })
+
+  it('returns null when toPng yields a malformed data URL', async () => {
+    toPngMock.mockResolvedValue('garbage-without-comma')
+
+    const b64 = await rasterizeNode(makeNode([]))
+
+    expect(b64).toBeNull()
+  })
+})
+
+describe('computePageBounds (headless render sizing)', () => {
+  const basePage: BoardPage = { id: 'p1', orderIndex: 1, elements: [], strokes: [] }
+
+  it('returns the default viewport for an empty page', () => {
+    expect(computePageBounds(basePage)).toEqual({ x: 0, y: 0, w: 800, h: 600 })
+  })
+
+  it('expands to include an image element placed beyond the viewport', () => {
+    const page: BoardPage = {
+      ...basePage,
+      elements: [{ type: 'image', id: 'i1', x: 900, y: 700, w: 320, h: 240, file: 'photo.jpg', z: 1 }]
+    }
+    const b = computePageBounds(page)
+    expect(b.x).toBe(0)
+    expect(b.y).toBe(0)
+    expect(b.w).toBe(900 + 320 + 40) // element right edge + padding
+    expect(b.h).toBe(700 + 240 + 40)
+  })
+
+  it('includes negative-coordinate strokes and caps dimensions', () => {
+    const page: BoardPage = {
+      ...basePage,
+      strokes: [{ id: 's1', tool: 'pen', color: '#fff', width: 4, points: [{ x: -100, y: -50 }, { x: 99999, y: 10 }] }]
+    }
+    const b = computePageBounds(page)
+    expect(b.x).toBeLessThan(0)
+    expect(b.y).toBeLessThan(0)
+    expect(b.w).toBeLessThanOrEqual(4000)
+    expect(b.h).toBeLessThanOrEqual(4000)
+  })
+})

--- a/tests/unit/board-vision-routes.test.ts
+++ b/tests/unit/board-vision-routes.test.ts
@@ -121,3 +121,73 @@ describe('GET /board/pages/:n/render', () => {
     expect(res.body.error).toBe('Board unavailable')
   })
 })
+
+describe('GET /board/pages/:n/render — on-demand render (requestRender)', () => {
+  it('triggers a fresh render and returns 200 when the render then exists', async () => {
+    // First renderPath call: no PNG yet (''); after requestRender: real path.
+    let rendered = false
+    const bridge = makeBridge({
+      renderPath: vi.fn((n: number) => (n === 1 ? (rendered ? '/abs/page-aaa.png' : '') : null)),
+      requestRender: vi.fn(async (_n: number) => { rendered = true; return { ok: true } })
+    })
+    const app = makeApp(bridge)
+
+    const res = await request(app).get('/board/pages/1/render')
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ path: '/abs/page-aaa.png', page: 1 })
+    expect(bridge.requestRender).toHaveBeenCalledWith(1)
+  })
+
+  it('returns 409 with the renderer error when the fresh render fails', async () => {
+    const bridge = makeBridge({
+      renderPath: vi.fn((n: number) => (n === 1 ? '' : null)),
+      requestRender: vi.fn(async (_n: number) => ({ ok: false, error: 'image decode failed' }))
+    })
+    const app = makeApp(bridge)
+
+    const res = await request(app).get('/board/pages/1/render')
+
+    expect(res.status).toBe(409)
+    expect(res.body.error).toMatch(/could not be rendered: image decode failed/)
+    expect(res.body.error).toMatch(/Open it in the Workboard/)
+  })
+
+  it('returns 409 with an actionable message when requestRender throws', async () => {
+    const bridge = makeBridge({
+      renderPath: vi.fn((n: number) => (n === 1 ? '' : null)),
+      requestRender: vi.fn(async (_n: number) => { throw new Error('renderer crashed') })
+    })
+    const app = makeApp(bridge)
+
+    const res = await request(app).get('/board/pages/1/render')
+
+    expect(res.status).toBe(409)
+    expect(res.body.error).toMatch(/could not be rendered: renderer crashed/)
+  })
+
+  it('keeps the legacy 409 when the bridge has no requestRender', async () => {
+    const bridge = makeBridge({
+      renderPath: vi.fn((n: number) => (n === 1 ? '' : null))
+    })
+    const app = makeApp(bridge)
+
+    const res = await request(app).get('/board/pages/1/render')
+
+    expect(res.status).toBe(409)
+    expect(res.body.error).toMatch(/no render yet/)
+  })
+
+  it('does not call requestRender when the render already exists', async () => {
+    const bridge = makeBridge({
+      renderPath: vi.fn((n: number) => (n === 1 ? '/abs/page-aaa.png' : null)),
+      requestRender: vi.fn(async (_n: number) => ({ ok: true }))
+    })
+    const app = makeApp(bridge)
+
+    const res = await request(app).get('/board/pages/1/render')
+
+    expect(res.status).toBe(200)
+    expect(bridge.requestRender).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Problem
Owner hit a 409 ("Page N has no render yet — open it in the Workboard first") when an agent tried to review a Sketchpad page with a photo via `view_sketchpad_page`.

## Repro → actual root cause
Reproduced in an isolated instance (own worktree build, isolated `XDG_CONFIG_HOME`, xvfb + playwright-core `_electron`), pasting a real photo into the Sketchpad:

- **The suspected cacheBust+data-URL rasterization failure does NOT occur.** `toPng` with `cacheBust: true` on pages containing data-URL photos succeeds in both a clean Chromium harness (0.5–6.7 MB photos) and the real app DOM — the live debounced render saves a correct PNG with the photo in it.
- **The real hole is structural:** the render PNG is only ever written by `BoardPageCanvas` while that page is open in the Workboard (1500 ms debounced edit effect / fire-and-forget unmount). Any page not (re)visited since its last change — or whose unmount render lost the race with app close — has no PNG, and `/board/pages/:n/render` could only 409. There is no recovery path, and `rasterizeNode`'s silent `catch { return null }` hides any genuine rasterization failure (so the owner's actual error, if any, was unobservable by design).

## Fix
1. **Render on demand (the cure):** `GET /board/pages/:n/render` now triggers and awaits a fresh headless render when no PNG exists (`BoardBridge.requestRender` → `BOARD_RENDER_REQUEST`/`BOARD_RENDER_RESULT` IPC round-trip, 15 s timeout). Only if that still fails does it 409 — now with the real renderer error in an actionable message.
2. **Headless renderer (`src/renderer/board-render-service.ts`):** paints any page (notes / text / images / strokes — strokes via the exported `renderStroke` used by the live overlay) onto an offscreen canvas sized to content bounds, saves through the existing `BOARD_SAVE_RENDER` IPC. Works with the Workboard closed; broken images degrade per-element, not per-page.
3. **Rasterizer hardening (`useBoardRasterizer.ts`):** awaits `img.decode()` before `toPng`; `cacheBust` off (useless for data: URLs, defeats html-to-image's cache otherwise); silent catch replaced with `console.error` of the real cause (still returns null).

## Before / after (E2E, real app)
- Before: delete a photo page's render PNG → route returns **409** forever until the owner reopens the page.
- After: same state → route returns **200**, PNG regenerated headlessly, photo visible in it. Non-existent page still 404s; bridges without `requestRender` keep the legacy 409.

## Tests & discipline
- `tests/unit/board-rasterizer.test.ts` (new): image-element decode await, bare-base64 extraction, cacheBust:false assertion, error-logging on throw, malformed data URL → null; `computePageBounds` sizing.
- `tests/unit/board-vision-routes.test.ts` (+5): on-demand 200, failure 409 with reason, thrown requestRender 409, legacy 409 without requestRender, no spurious requestRender when PNG exists.
- `tsc --noEmit` clean; `npm run dev` boots (port auto-bump verified); 21/21 board tests pass. Pre-existing better-sqlite3-ABI test failures (Electron-rebuilt native module vs node vitest) are untouched and identical on origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)