### PR TITLE
Telegram orchestration: pairing, commands, files/photos/voice, inbox mirror & proposal approvals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@xterm/xterm": "^6.0.0",
         "better-sqlite3": "^12.8.0",
         "express": "^5.2.1",
+        "grammy": "^1.44.0",
         "html-to-image": "^1.11.13",
         "nanoid": "^5.1.9",
         "node-pty": "^1.1.0",
@@ -940,6 +941,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@grammyjs/types": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@grammyjs/types/-/types-3.28.0.tgz",
+      "integrity": "sha512-4JvXCdxRZHCje0M4gHzLwtB4bLno3WD28xd8CNfk4POWIu73BFnSvGeW6OQ5gPem4eYTEwkD9yDaXssixl6tMQ==",
+      "license": "MIT"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
@@ -2476,6 +2483,18 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/accepts": {
@@ -4139,7 +4158,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4150,7 +4168,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -4335,6 +4352,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/eventemitter3": {
@@ -4977,6 +5003,21 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/grammy": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/grammy/-/grammy-1.44.0.tgz",
+      "integrity": "sha512-gGVykS5+c5f1tPV97LuU6IDRMawE2NzpwM9pNz58HQ35IZXDnYL3VOLvNzYognPSeBIOSzQXRu5w96V0aY8y8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@grammyjs/types": "3.28.0",
+        "abort-controller": "^3.0.0",
+        "debug": "^4.4.3",
+        "node-fetch": "^2.7.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || >=14.13.1"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -5941,6 +5982,26 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-gyp": {
@@ -7733,6 +7794,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -8106,6 +8173,22 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@xterm/xterm": "^6.0.0",
     "better-sqlite3": "^12.8.0",
     "express": "^5.2.1",
+    "grammy": "^1.44.0",
     "html-to-image": "^1.11.13",
     "nanoid": "^5.1.9",
     "node-pty": "^1.1.0",

--- a/scripts/encode-bug-token.mjs
+++ b/scripts/encode-bug-token.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Encode a GitHub PAT into the obfuscated `_bt` byte array the bug-report
+// button uses (src/main/index.ts). Run this LOCALLY so the raw token never
+// lands in chat, logs, or a committed plaintext file — only the XOR-obfuscated
+// numbers (which already live in the public repo by design) are emitted.
+//
+// Usage:
+//   node scripts/encode-bug-token.mjs <PAT>            # print the line to paste
+//   node scripts/encode-bug-token.mjs <PAT> --write    # patch src/main/index.ts in place
+//   BUG_PAT=<PAT> node scripts/encode-bug-token.mjs    # pass via env instead of argv
+//
+// Matches the deobfuscation in src/main/index.ts: byte[i] = pat[i] ^ key[i % key.length]
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const KEY = 'TheCogBugReporter2026'
+const INDEX_PATH = join(dirname(fileURLToPath(import.meta.url)), '..', 'src', 'main', 'index.ts')
+
+const args = process.argv.slice(2)
+const write = args.includes('--write')
+const pat = (args.find(a => !a.startsWith('--')) ?? process.env.BUG_PAT ?? '').trim()
+
+if (!pat) {
+  console.error('No PAT provided. Pass it as the first argument or set BUG_PAT.')
+  process.exit(1)
+}
+if (!pat.startsWith('github_pat_') && !pat.startsWith('ghp_')) {
+  console.error(`Warning: "${pat.slice(0, 8)}…" doesn't look like a GitHub PAT — continuing anyway.`)
+}
+
+const bytes = Array.from(pat).map((ch, i) => ch.charCodeAt(0) ^ KEY.charCodeAt(i % KEY.length))
+
+// Round-trip guard: never emit an array that doesn't decode back to the input.
+const decoded = bytes.map((c, i) => String.fromCharCode(c ^ KEY.charCodeAt(i % KEY.length))).join('')
+if (decoded !== pat) {
+  console.error('Encoding failed round-trip check — aborting.')
+  process.exit(1)
+}
+
+const line = `  const _bt = [${bytes.join(',')}]`
+
+if (write) {
+  const src = readFileSync(INDEX_PATH, 'utf8')
+  const re = /^ {2}const _bt = \[[0-9,]+\]$/m
+  if (!re.test(src)) {
+    console.error(`Could not find the "_bt" line in ${INDEX_PATH}. Patch it by hand.`)
+    process.exit(1)
+  }
+  writeFileSync(INDEX_PATH, src.replace(re, line), 'utf8')
+  console.log(`✓ Patched ${INDEX_PATH} with the new bug-report token (prefix ${pat.slice(0, 11)}, len ${pat.length}).`)
+} else {
+  console.log(`Replace the "_bt" line in src/main/index.ts (~line 2627) with:\n`)
+  console.log(line)
+  console.log(`\nOr re-run with --write to patch the file automatically.`)
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,6 +37,7 @@ import { PairingManager } from './telegram/pairing-manager'
 import { TelegramServer, validateBotToken } from './telegram/telegram-server'
 import { stripAnsi } from './telegram/ansi'
 import type { OrchestratorBridge } from './telegram/bridge'
+import { sanitizeFilename, isTextFile, buildAttachmentMessage, TEXT_INLINE_LIMIT } from './telegram/attachment'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
 import * as workspaceThemeStore from './themes/workspace-theme-store'
@@ -681,6 +682,38 @@ function telegramBridge(): OrchestratorBridge {
       if (!hub) return { ok: false, detail: 'No project is open yet.' }
       const res = hub.messages.send('user', name, text)
       return res.status === 'error' ? { ok: false, detail: res.detail } : { ok: true }
+    },
+    sendFile: (name, file) => {
+      if (!hub) return { ok: false, detail: 'No project is open yet.' }
+      const projectPath = projectManager?.currentProject?.path
+      if (!projectPath) return { ok: false, detail: 'No project is open yet.' }
+      try {
+        // Save into the project so the agent (cwd = project root) can open it.
+        const safeName = sanitizeFilename(file.filename)
+        const inboxDir = path.join(projectPath, '.cog', 'telegram-inbox')
+        fs.mkdirSync(inboxDir, { recursive: true })
+        fs.writeFileSync(path.join(inboxDir, safeName), file.bytes)
+        const relPath = ['.cog', 'telegram-inbox', safeName].join('/')
+
+        const isImage = (file.mimeType?.startsWith('image/') ?? false) ||
+          /\.(jpe?g|png|gif|webp|bmp|heic|heif)$/i.test(safeName)
+
+        // Inline small text files; everything else is referenced by path.
+        let textContent: string | null = null
+        let truncated = false
+        if (isTextFile(file.filename, file.mimeType)) {
+          const decoded = Buffer.from(file.bytes).toString('utf8')
+          truncated = decoded.length > TEXT_INLINE_LIMIT
+          textContent = truncated ? decoded.slice(0, TEXT_INLINE_LIMIT) : decoded
+        }
+
+        const msg = buildAttachmentMessage({ filename: safeName, relPath, caption: file.caption, isImage, textContent, truncated })
+        const res = hub.messages.send('user', name, msg)
+        if (res.status === 'error') return { ok: false, detail: res.detail }
+        return { ok: true, relPath }
+      } catch (err) {
+        return { ok: false, detail: (err as Error).message }
+      }
     },
     getOutput: (name, lines) => {
       const managed = Array.from(agents.values()).find(m => m.config.name === name)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -37,7 +37,7 @@ import { PairingManager } from './telegram/pairing-manager'
 import { TelegramServer, validateBotToken } from './telegram/telegram-server'
 import { stripAnsi } from './telegram/ansi'
 import type { OrchestratorBridge, ProposalView } from './telegram/bridge'
-import { sanitizeFilename, isTextFile, buildAttachmentMessage, TEXT_INLINE_LIMIT } from './telegram/attachment'
+import { sanitizeFilename, isTextFile, isImageFile, buildAttachmentMessage, TEXT_INLINE_LIMIT } from './telegram/attachment'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
 import * as workspaceThemeStore from './themes/workspace-theme-store'
@@ -616,13 +616,18 @@ function emitTelegramStatus(): void {
 }
 
 // Save a Telegram-supplied file into the project's inbox folder (agent cwd =
-// project root, so it can open the returned relative path). Returns { relPath }.
-function saveTelegramInboxFile(projectPath: string, filename: string, bytes: Uint8Array): { relPath: string } {
-  const safeName = sanitizeFilename(filename)
+// project root, so it can open the returned relative path). Disambiguates on
+// name collision so two same-named uploads don't clobber each other.
+function saveTelegramInboxFile(projectPath: string, filename: string, bytes: Uint8Array): { relPath: string; safeName: string } {
   const inboxDir = path.join(projectPath, '.cog', 'telegram-inbox')
   fs.mkdirSync(inboxDir, { recursive: true })
+  let safeName = sanitizeFilename(filename)
+  if (fs.existsSync(path.join(inboxDir, safeName))) {
+    const ext = path.extname(safeName)
+    safeName = `${safeName.slice(0, safeName.length - ext.length)}-${Date.now()}${ext}`
+  }
   fs.writeFileSync(path.join(inboxDir, safeName), bytes)
-  return { relPath: ['.cog', 'telegram-inbox', safeName].join('/') }
+  return { relPath: ['.cog', 'telegram-inbox', safeName].join('/'), safeName }
 }
 
 /**
@@ -649,11 +654,8 @@ function telegramBridge(): OrchestratorBridge {
       if (!projectPath) return { ok: false, detail: 'No project is open yet.' }
       try {
         // Save into the project so the agent (cwd = project root) can open it.
-        const safeName = sanitizeFilename(file.filename)
-        const { relPath } = saveTelegramInboxFile(projectPath, file.filename, file.bytes)
-
-        const isImage = (file.mimeType?.startsWith('image/') ?? false) ||
-          /\.(jpe?g|png|gif|webp|bmp|heic|heif)$/i.test(safeName)
+        const { relPath, safeName } = saveTelegramInboxFile(projectPath, file.filename, file.bytes)
+        const isImage = isImageFile(safeName, file.mimeType)
 
         // Inline small text files; everything else is referenced by path.
         let textContent: string | null = null
@@ -1417,7 +1419,18 @@ async function approveProposalById(proposalId: string): Promise<{ success: boole
 
 function rejectProposalById(proposalId: string, feedback?: string): { success: boolean; error?: string } {
   if (!hub) return { success: false, error: 'Hub not ready' }
-  const resolved = hub.proposalsChannel.resolve(proposalId, 'rejected', feedback)
+  const proposal = hub.proposalsChannel.get(proposalId)
+  if (!proposal) return { success: false, error: 'Proposal not found' }
+  // resolve() THROWS (not returns null) for an already-settled proposal, so a
+  // second tapper racing an approve would otherwise reject the callback promise
+  // before answerCallbackQuery runs. Guard + catch keeps it graceful.
+  if (proposal.status !== 'pending') return { success: false, error: `Proposal already ${proposal.status}` }
+  let resolved
+  try {
+    resolved = hub.proposalsChannel.resolve(proposalId, 'rejected', feedback)
+  } catch (err) {
+    return { success: false, error: (err as Error).message }
+  }
   if (!resolved) return { success: false, error: 'Proposal not found' }
   try {
     const note = feedback
@@ -1576,8 +1589,13 @@ function setupMessageNudge(): void {
     if (msg.to === 'user') {
       const settings = loadSettings()
       if (settings.notifications !== false) {
-        // Telegram mirroring lives on the inbox channel (onMessageAdded) so it
-        // carries urgency and respects the telegram threshold — see below.
+        // Relay conversational agent→user replies to Telegram so the chat loop
+        // works both ways. This is a different channel from the inbox (below):
+        // send_message→user lands here; notify_user lands in inboxChannel. They
+        // don't overlap, so this is not a double-send. Conversational replies
+        // always relay (you're actively chatting); the inbox stream is the one
+        // gated by the telegram priority threshold.
+        telegramServer?.relayFromAgent(msg.from, msg.message)
         const preview = msg.message.length > 120 ? msg.message.slice(0, 120) + '…' : msg.message
         const notification = new Notification({
           title: `Message from ${msg.from}`,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2688,7 +2688,7 @@ function setupIPC(): void {
   // Bug report — posts directly to GitHub Issues via API (no user login needed)
   // Token is obfuscated (not plaintext) to avoid automated scanners. Issues-only permission on a single repo.
   const _bk = 'TheCogBugReporter2026'
-  const _bt = [51,1,17,43,26,5,29,5,6,38,58,65,94,51,51,46,61,115,122,123,6,19,49,83,57,36,36,48,56,46,40,50,5,48,8,56,53,58,65,97,92,103,51,17,50,53,1,87,10,68,80,38,12,31,93,55,25,31,42,123,102,119,115,13,11,34,10,58,52,15,77,3,22,52,17,14,26,64,47,33,103,98,6,123,99,39,29,51,27,44,6,58,14]
+  const _bt = [51,1,17,43,26,5,29,5,6,38,58,65,94,51,51,46,61,115,122,123,6,36,62,32,55,7,54,113,50,45,58,46,7,48,7,26,44,70,80,1,90,87,0,45,2,12,5,41,123,69,85,48,32,55,30,55,58,19,58,11,98,67,95,101,43,39,113,39,51,39,59,44,54,82,17,9,32,53,43,42,127,118,1,96,22,38,93,49,63,13,39,2,43]
   const _deobf = (): string => _bt.map((c, i) => String.fromCharCode(c ^ _bk.charCodeAt(i % _bk.length))).join('')
 
   ipcMain.handle(IPC.BUG_REPORT_SUBMIT, async (_event, report: { title: string; body: string }) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -46,7 +46,7 @@ import { migrateLegacyUserData } from './migration/userdata-migration'
 import type { AgentConfig, AgentTheme, RemoteSetupProgress, CommunityAgent, CommunityCategory, RespawnResult, NotificationThreshold, ProposedAgent, TeamProposal, TelegramStatus } from '../shared/types'
 import { IPC } from '../shared/types'
 import { validateRespawnRequest } from './respawn-validation'
-import { initStreamDeck, disposeStreamDeck, resolveCogsworthDir, getStreamDeckStatus, reconnectStreamDeck } from './streamdeck'
+import { initStreamDeck, disposeStreamDeck, resolveCogsworthDir, getStreamDeckStatus, reconnectStreamDeck, buildWhisperClient } from './streamdeck'
 import { prepareLocalWhisper, isLocalWhisperReady } from './streamdeck/local-whisper-prepare'
 import { BoardStore } from './db/board-store'
 import { BoardAppearanceStore } from './db/board-appearance-store'
@@ -615,6 +615,16 @@ function emitTelegramStatus(): void {
   mainWindow.webContents.send(IPC.TELEGRAM_STATUS_UPDATE, telegramStatus())
 }
 
+// Save a Telegram-supplied file into the project's inbox folder (agent cwd =
+// project root, so it can open the returned relative path). Returns { relPath }.
+function saveTelegramInboxFile(projectPath: string, filename: string, bytes: Uint8Array): { relPath: string } {
+  const safeName = sanitizeFilename(filename)
+  const inboxDir = path.join(projectPath, '.cog', 'telegram-inbox')
+  fs.mkdirSync(inboxDir, { recursive: true })
+  fs.writeFileSync(path.join(inboxDir, safeName), bytes)
+  return { relPath: ['.cog', 'telegram-inbox', safeName].join('/') }
+}
+
 /**
  * Hub-backed implementation of the Telegram bot's orchestration bridge. Reads
  * `hub`/`agents` lazily (a project may not be open yet when the bot starts), so
@@ -640,10 +650,7 @@ function telegramBridge(): OrchestratorBridge {
       try {
         // Save into the project so the agent (cwd = project root) can open it.
         const safeName = sanitizeFilename(file.filename)
-        const inboxDir = path.join(projectPath, '.cog', 'telegram-inbox')
-        fs.mkdirSync(inboxDir, { recursive: true })
-        fs.writeFileSync(path.join(inboxDir, safeName), file.bytes)
-        const relPath = ['.cog', 'telegram-inbox', safeName].join('/')
+        const { relPath } = saveTelegramInboxFile(projectPath, file.filename, file.bytes)
 
         const isImage = (file.mimeType?.startsWith('image/') ?? false) ||
           /\.(jpe?g|png|gif|webp|bmp|heic|heif)$/i.test(safeName)
@@ -679,6 +686,44 @@ function telegramBridge(): OrchestratorBridge {
       try {
         const task = hub.pinboard.postTask(title, '', 'medium', 'telegram-user')
         return { ok: true, id: task.id }
+      } catch (err) {
+        return { ok: false, detail: (err as Error).message }
+      }
+    },
+    sendVoice: async (name, voice) => {
+      if (!hub) return { ok: false, detail: 'No project is open yet.' }
+      const s = loadSettings()
+      const whisper = buildWhisperClient({
+        whisperBackend: typeof s.whisperBackend === 'string' ? s.whisperBackend : '',
+        openaiApiKey: typeof s.openaiApiKey === 'string' ? s.openaiApiKey : undefined
+      })
+      if (whisper) {
+        try {
+          // Copy into a fresh, non-shared ArrayBuffer for the transcriber.
+          const ab = new Uint8Array(voice.bytes).buffer as ArrayBuffer
+          const transcript = (await whisper.transcribe(ab)).trim()
+          if (transcript) {
+            const caption = voice.caption?.trim()
+            const msg = caption ? `🎙️ (voice) ${transcript}\n\n${caption}` : `🎙️ (voice) ${transcript}`
+            const res = hub.messages.send('user', name, msg)
+            if (res.status === 'error') return { ok: false, detail: res.detail }
+            return { ok: true, transcript }
+          }
+          // Empty transcript → fall through to saving the audio.
+        } catch (err) {
+          console.warn('[telegram] voice transcription failed:', (err as Error).message)
+          // Fall through to saving the audio.
+        }
+      }
+      // Fallback: no Whisper backend (or it failed) — save the audio + hand over the path.
+      const projectPath = projectManager?.currentProject?.path
+      if (!projectPath) return { ok: false, detail: 'No project is open yet.' }
+      try {
+        const { relPath } = saveTelegramInboxFile(projectPath, `telegram-voice-${Date.now()}.ogg`, voice.bytes)
+        const why = whisper ? 'couldn\'t transcribe' : 'Whisper not configured (Settings → Voice)'
+        const res = hub.messages.send('user', name, `🎙️ Voice note saved to ${relPath} (${why}).`)
+        if (res.status === 'error') return { ok: false, detail: res.detail }
+        return { ok: true, detail: why }
       } catch (err) {
         return { ok: false, detail: (err as Error).message }
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -36,7 +36,7 @@ import { RemoteWsHub } from './remote/ws-hub'
 import { PairingManager } from './telegram/pairing-manager'
 import { TelegramServer, validateBotToken } from './telegram/telegram-server'
 import { stripAnsi } from './telegram/ansi'
-import type { OrchestratorBridge } from './telegram/bridge'
+import type { OrchestratorBridge, ProposalView } from './telegram/bridge'
 import { sanitizeFilename, isTextFile, buildAttachmentMessage, TEXT_INLINE_LIMIT } from './telegram/attachment'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
@@ -488,59 +488,9 @@ async function enableRemoteView(): Promise<void> {
       if (!hub) return false
       return hub.inboxChannel.markRead(id) !== null
     },
-    approveProposal: async (proposalId: string) => {
-      if (!hub) return { success: false, error: 'Hub not ready' }
-      const proposal = hub.proposalsChannel.get(proposalId)
-      if (!proposal) return { success: false, error: 'Proposal not found' }
-      if (proposal.status !== 'pending') {
-        return { success: false, error: `Proposal already ${proposal.status}` }
-      }
-      if (proposal.kind === 'schedule') {
-        if (!proposal.payload) {
-          return { success: false, error: 'Schedule proposal missing payload' }
-        }
-        if (!scheduleBridge) {
-          return { success: false, error: 'Scheduler unavailable' }
-        }
-        try {
-          scheduleBridge.create({
-            agentId: proposal.payload.targetAgentId,
-            tabId: proposal.payload.tabId,
-            name: proposal.payload.name,
-            promptText: proposal.payload.promptText,
-            intervalMinutes: proposal.payload.intervalMinutes,
-            durationHours: proposal.payload.durationHours,
-            createdBy: proposal.proposedBy
-          })
-        } catch (err: any) {
-          return { success: false, error: err?.message || 'Failed to create schedule' }
-        }
-        hub.proposalsChannel.resolve(proposalId, 'approved')
-        return { success: true }
-      }
-      // 3DS approves as-stored — no per-agent edits available on the small screen.
-      const { spawned, total, names } = spawnProposalAgents(proposal)
-      hub.proposalsChannel.resolve(proposalId, 'approved')
-      try {
-        const summary = spawned === total
-          ? `User approved your team from 3DS. Spawned: ${names.join(', ')}.`
-          : `User approved part of your team from 3DS. Spawned ${spawned}/${total}.`
-        hub.messages.send('user', proposal.proposedBy, summary)
-      } catch { /* orchestrator may not be reachable */ }
-      return { success: true, spawned }
-    },
-    rejectProposal: (proposalId: string, feedback?: string) => {
-      if (!hub) return { success: false, error: 'Hub not ready' }
-      const resolved = hub.proposalsChannel.resolve(proposalId, 'rejected', feedback)
-      if (!resolved) return { success: false, error: 'Proposal not found' }
-      try {
-        const note = feedback
-          ? `User rejected your team proposal from 3DS. Feedback: ${feedback}`
-          : 'User rejected your team proposal from 3DS.'
-        hub.messages.send('user', resolved.proposedBy, note)
-      } catch { /* orchestrator may not be reachable */ }
-      return { success: true }
-    },
+    // Shared with the Telegram bridge — approve/reject a proposal as-stored.
+    approveProposal: (proposalId: string) => approveProposalById(proposalId),
+    rejectProposal: (proposalId: string, feedback?: string) => rejectProposalById(proposalId, feedback),
     replyToInbox: (agentName: string, message: string) => {
       if (!hub) return { success: false, error: 'Hub not ready' }
       try {
@@ -732,6 +682,18 @@ function telegramBridge(): OrchestratorBridge {
       } catch (err) {
         return { ok: false, detail: (err as Error).message }
       }
+    },
+    approveProposal: async (id) => {
+      const r = await approveProposalById(id)
+      return r.success ? { ok: true } : { ok: false, detail: r.error }
+    },
+    rejectProposal: async (id) => {
+      const r = rejectProposalById(id)
+      return r.success ? { ok: true } : { ok: false, detail: r.error }
+    },
+    getProposal: (id) => {
+      const p = hub?.proposalsChannel.get(id)
+      return p ? toProposalView(p) : null
     }
   }
 }
@@ -1368,6 +1330,73 @@ function spawnProposalAgents(proposal: TeamProposal): { spawned: number; total: 
   return { spawned, total: ordered.length, names }
 }
 
+// Approve a pending proposal as-stored (no per-agent edits — the desktop modal
+// owns that path). Spawns the team or creates the schedule, then resolves it.
+// Shared by the 3DS remote bridge and the Telegram bot.
+async function approveProposalById(proposalId: string): Promise<{ success: boolean; error?: string; spawned?: number }> {
+  if (!hub) return { success: false, error: 'Hub not ready' }
+  const proposal = hub.proposalsChannel.get(proposalId)
+  if (!proposal) return { success: false, error: 'Proposal not found' }
+  if (proposal.status !== 'pending') {
+    return { success: false, error: `Proposal already ${proposal.status}` }
+  }
+  if (proposal.kind === 'schedule') {
+    if (!proposal.payload) return { success: false, error: 'Schedule proposal missing payload' }
+    if (!scheduleBridge) return { success: false, error: 'Scheduler unavailable' }
+    try {
+      scheduleBridge.create({
+        agentId: proposal.payload.targetAgentId,
+        tabId: proposal.payload.tabId,
+        name: proposal.payload.name,
+        promptText: proposal.payload.promptText,
+        intervalMinutes: proposal.payload.intervalMinutes,
+        durationHours: proposal.payload.durationHours,
+        createdBy: proposal.proposedBy
+      })
+    } catch (err: any) {
+      return { success: false, error: err?.message || 'Failed to create schedule' }
+    }
+    hub.proposalsChannel.resolve(proposalId, 'approved')
+    return { success: true }
+  }
+  const { spawned, total, names } = spawnProposalAgents(proposal)
+  hub.proposalsChannel.resolve(proposalId, 'approved')
+  try {
+    const summary = spawned === total
+      ? `User approved your team. Spawned: ${names.join(', ')}.`
+      : `User approved part of your team. Spawned ${spawned}/${total}.`
+    hub.messages.send('user', proposal.proposedBy, summary)
+  } catch { /* orchestrator may not be reachable */ }
+  return { success: true, spawned }
+}
+
+function rejectProposalById(proposalId: string, feedback?: string): { success: boolean; error?: string } {
+  if (!hub) return { success: false, error: 'Hub not ready' }
+  const resolved = hub.proposalsChannel.resolve(proposalId, 'rejected', feedback)
+  if (!resolved) return { success: false, error: 'Proposal not found' }
+  try {
+    const note = feedback
+      ? `User rejected your team proposal. Feedback: ${feedback}`
+      : 'User rejected your team proposal.'
+    hub.messages.send('user', resolved.proposedBy, note)
+  } catch { /* orchestrator may not be reachable */ }
+  return { success: true }
+}
+
+// Flatten a TeamProposal into the bot-facing ProposalView (decoupled shape).
+function toProposalView(p: TeamProposal): ProposalView {
+  return {
+    id: p.id,
+    proposedBy: p.proposedBy,
+    summary: p.summary,
+    kind: p.kind,
+    status: p.status,
+    agents: p.agents.map(a => ({
+      name: a.name, role: a.role, cli: a.cli, model: a.model, notes: a.ceoNotes
+    }))
+  }
+}
+
 // Single source of truth for fully tearing down a live agent: kill the PTY,
 // unregister from the hub, clear nudge state, drop config, and tell the
 // renderer to remove the window. Used by every kill path.
@@ -1502,10 +1531,8 @@ function setupMessageNudge(): void {
     if (msg.to === 'user') {
       const settings = loadSettings()
       if (settings.notifications !== false) {
-        // Mirror it to any linked Telegram chats. No-op when the bot is off or
-        // nobody's paired. Inside the notifications gate on purpose: muting
-        // notifications should silence the phone too, not just the desktop.
-        telegramServer?.relayFromAgent(msg.from, msg.message)
+        // Telegram mirroring lives on the inbox channel (onMessageAdded) so it
+        // carries urgency and respects the telegram threshold — see below.
         const preview = msg.message.length > 120 ? msg.message.slice(0, 120) + '…' : msg.message
         const notification = new Notification({
           title: `Message from ${msg.from}`,
@@ -1768,6 +1795,12 @@ async function openProject(projectPath: string): Promise<void> {
         n.show()
       } catch { /* notifications may be disabled at OS level */ }
     }
+    // Mirror the inbox to Telegram with its urgency. Baseline is everything
+    // (threshold 'low'); the user can raise telegramNotifyThreshold in Settings.
+    const tgThreshold = (settings.telegramNotifyThreshold || 'low') as NotificationThreshold
+    if (tgThreshold !== 'none' && meetsThreshold(msg.priority, tgThreshold)) {
+      telegramServer?.relayFromAgent(msg.agentName, msg.message, msg.priority)
+    }
   }
   hub.inboxChannel.onMessageUpdated = (msg) => {
     inboxStore.markRead(msg.id, msg.readAt ?? new Date().toISOString())
@@ -1799,6 +1832,9 @@ async function openProject(projectPath: string): Promise<void> {
       return
     }
     mainWindow?.webContents.send(IPC.PROPOSAL_ADDED, proposal)
+    // Also push it to Telegram with Approve/Reject/Details buttons so it can be
+    // actioned on the go. Resolving anywhere edits every surface via onProposalResolved.
+    void telegramServer?.relayProposal(toProposalView(proposal))
     // Show the main window so the user notices the modal
     if (mainWindow && !mainWindow.isFocused()) {
       mainWindow.show()
@@ -1812,6 +1848,11 @@ async function openProject(projectPath: string): Promise<void> {
       proposal.resolvedAt ?? new Date().toISOString(),
       proposal.feedback
     )
+    // Tell every surface it's settled: the desktop popup auto-closes if it's
+    // showing this one, the inbox drops its Review button, Telegram edits its
+    // message. Fires no matter who resolved it (desktop, 3DS, or Telegram).
+    mainWindow?.webContents.send(IPC.PROPOSAL_RESOLVED, proposal)
+    telegramServer?.relayProposalResolved(toProposalView(proposal))
   }
 
   hub.setOutputAccessor((agentName, lines) => {
@@ -2396,6 +2437,15 @@ function setupIPC(): void {
   ipcMain.handle(IPC.PROPOSALS_LIST_PENDING, () => hub?.proposalsChannel.listPending() ?? [])
   ipcMain.handle(IPC.PROPOSALS_GET, (_event, id: string) => {
     return hub?.proposalsChannel.get(id) ?? null
+  })
+  // Re-surface a still-pending proposal's modal from the inbox (or anywhere).
+  // Reuses the exact PROPOSAL_ADDED path the initial popup uses.
+  ipcMain.handle(IPC.PROPOSALS_REOPEN, (_event, id: string) => {
+    const proposal = hub?.proposalsChannel.get(id)
+    if (!proposal) return { ok: false, status: 'missing' as const }
+    if (proposal.status !== 'pending') return { ok: false, status: proposal.status }
+    mainWindow?.webContents.send(IPC.PROPOSAL_ADDED, proposal)
+    return { ok: true, status: 'pending' as const }
   })
   ipcMain.handle(IPC.PROPOSALS_APPROVE, async (_event, payload: {
     proposalId: string

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import { RemoteServer } from './remote/remote-server'
 import { RemoteWsHub } from './remote/ws-hub'
 import { PairingManager } from './telegram/pairing-manager'
 import { TelegramServer } from './telegram/telegram-server'
+import type { OrchestratorBridge } from './telegram/bridge'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
 import * as workspaceThemeStore from './themes/workspace-theme-store'
@@ -626,6 +627,40 @@ function emitTelegramStatus(): void {
   })
 }
 
+/**
+ * Hub-backed implementation of the Telegram bot's orchestration bridge. Reads
+ * `hub`/`agents` lazily (a project may not be open yet when the bot starts), so
+ * every method tolerates a missing hub and reports it cleanly to the chat.
+ */
+function telegramBridge(): OrchestratorBridge {
+  return {
+    listTargets: () => {
+      if (!hub) return []
+      return hub.registry.list()
+        .filter(a => a.name !== 'user')
+        .map(a => ({ name: a.name, role: a.role, status: a.status }))
+    },
+    sendTo: (name, text) => {
+      if (!hub) return { ok: false, detail: 'No project is open yet.' }
+      const res = hub.messages.send('user', name, text)
+      return res.status === 'error' ? { ok: false, detail: res.detail } : { ok: true }
+    },
+    getOutput: (name, lines) => {
+      const managed = Array.from(agents.values()).find(m => m.config.name === name)
+      return managed ? managed.outputBuffer.getLines(lines) : []
+    },
+    postTask: (title) => {
+      if (!hub) return { ok: false, detail: 'No project is open yet.' }
+      try {
+        const task = hub.pinboard.postTask(title, '', 'medium', 'telegram-user')
+        return { ok: true, id: task.id }
+      } catch (err) {
+        return { ok: false, detail: (err as Error).message }
+      }
+    }
+  }
+}
+
 async function enableTelegram(): Promise<void> {
   if (telegramServer) return
   const s = loadSettings()
@@ -638,6 +673,7 @@ async function enableTelegram(): Promise<void> {
   })
   telegramServer = new TelegramServer({
     pairing: telegramPairing,
+    bridge: telegramBridge(),
     onLog: (m) => console.log('[telegram]', m),
     onStatusChange: () => emitTelegramStatus()
   })
@@ -1368,6 +1404,9 @@ function setupMessageNudge(): void {
   hub.messages.onMessageQueued = (msg) => {
     // When an agent messages the user, show an OS notification
     if (msg.to === 'user') {
+      // Mirror it to any linked Telegram chats (Phase 1 relay). No-op when the
+      // bot is off or nobody's paired.
+      telegramServer?.relayFromAgent(msg.from, msg.message)
       const settings = loadSettings()
       if (settings.notifications !== false) {
         const preview = msg.message.length > 120 ? msg.message.slice(0, 120) + '…' : msg.message

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, dialog, Notification, Menu, shell } from 'electron'
+import { app, BrowserWindow, ipcMain, dialog, Notification, Menu, shell, safeStorage } from 'electron'
 import path from 'path'
 import * as fs from 'fs'
 import * as gitOps from './git/git-ops'
@@ -34,14 +34,15 @@ import { CloudflaredManager } from './remote/cloudflared-manager'
 import { RemoteServer } from './remote/remote-server'
 import { RemoteWsHub } from './remote/ws-hub'
 import { PairingManager } from './telegram/pairing-manager'
-import { TelegramServer } from './telegram/telegram-server'
+import { TelegramServer, validateBotToken } from './telegram/telegram-server'
+import { stripAnsi } from './telegram/ansi'
 import type { OrchestratorBridge } from './telegram/bridge'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
 import * as workspaceThemeStore from './themes/workspace-theme-store'
 import { getWorkspaceThemeById, WORKSPACE_THEMES } from '../shared/workspace-themes'
 import { migrateLegacyUserData } from './migration/userdata-migration'
-import type { AgentConfig, AgentTheme, RemoteSetupProgress, CommunityAgent, CommunityCategory, RespawnResult, NotificationThreshold, ProposedAgent, TeamProposal } from '../shared/types'
+import type { AgentConfig, AgentTheme, RemoteSetupProgress, CommunityAgent, CommunityCategory, RespawnResult, NotificationThreshold, ProposedAgent, TeamProposal, TelegramStatus } from '../shared/types'
 import { IPC } from '../shared/types'
 import { validateRespawnRequest } from './respawn-validation'
 import { initStreamDeck, disposeStreamDeck, resolveCogsworthDir, getStreamDeckStatus, reconnectStreamDeck } from './streamdeck'
@@ -615,16 +616,50 @@ async function disableRemoteView(): Promise<void> {
 
 // ── Telegram orchestration helpers ───────────────────────────────────────────
 
-function emitTelegramStatus(): void {
-  if (!mainWindow) return
+/**
+ * The bot token unlocks sending/reading as the bot, so it's stored encrypted
+ * via Electron safeStorage (DPAPI on Windows) as `telegramBotTokenEnc`. A
+ * legacy plaintext `telegramBotToken` is still read as a fallback and upgraded
+ * on the next save. If the OS keychain is unavailable we fall back to
+ * plaintext rather than losing the feature.
+ */
+function saveTelegramToken(token: string): void {
+  if (token && safeStorage.isEncryptionAvailable()) {
+    saveSetting('telegramBotTokenEnc', safeStorage.encryptString(token).toString('base64'))
+    saveSetting('telegramBotToken', undefined)  // drop any legacy plaintext copy
+  } else {
+    saveSetting('telegramBotToken', token || undefined)
+    saveSetting('telegramBotTokenEnc', undefined)
+  }
+}
+
+function loadTelegramToken(): string {
   const s = loadSettings()
-  mainWindow.webContents.send(IPC.TELEGRAM_STATUS_UPDATE, {
+  const enc = s.telegramBotTokenEnc
+  if (typeof enc === 'string' && enc && safeStorage.isEncryptionAvailable()) {
+    try {
+      return safeStorage.decryptString(Buffer.from(enc, 'base64')).trim()
+    } catch (err) {
+      console.error('[telegram] failed to decrypt stored token:', err)
+    }
+  }
+  return typeof s.telegramBotToken === 'string' ? s.telegramBotToken.trim() : ''
+}
+
+function telegramStatus(): TelegramStatus {
+  const s = loadSettings()
+  return {
     enabled: telegramServer?.isRunning() ?? false,
-    hasToken: typeof s.telegramBotToken === 'string' && !!s.telegramBotToken,
+    hasToken: !!loadTelegramToken(),
     pairedCount: telegramPairing?.size
       ?? (Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist.length : 0),
     activePairingCode: telegramPairing?.getActiveCode() ?? null
-  })
+  }
+}
+
+function emitTelegramStatus(): void {
+  if (!mainWindow) return
+  mainWindow.webContents.send(IPC.TELEGRAM_STATUS_UPDATE, telegramStatus())
 }
 
 /**
@@ -647,7 +682,12 @@ function telegramBridge(): OrchestratorBridge {
     },
     getOutput: (name, lines) => {
       const managed = Array.from(agents.values()).find(m => m.config.name === name)
-      return managed ? managed.outputBuffer.getLines(lines) : []
+      if (!managed) return []
+      // OutputBuffer holds raw PTY bytes — strip ANSI/cursor noise or the
+      // Telegram reply is unreadable escape-code soup.
+      return managed.outputBuffer.getLines(lines)
+        .map(stripAnsi)
+        .filter((line) => line.trim().length > 0)
     },
     postTask: (title) => {
       if (!hub) return { ok: false, detail: 'No project is open yet.' }
@@ -661,12 +701,9 @@ function telegramBridge(): OrchestratorBridge {
   }
 }
 
-async function enableTelegram(): Promise<void> {
-  if (telegramServer) return
+/** Build and start the bot with the given token. Throws on a bad token/network. */
+async function startTelegram(token: string): Promise<void> {
   const s = loadSettings()
-  const token = typeof s.telegramBotToken === 'string' ? s.telegramBotToken.trim() : ''
-  if (!token) return  // no token yet — UI prompts for one
-
   telegramPairing = new PairingManager({
     initialAllowlist: Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist : [],
     onAllowlistChange: (ids) => saveSetting('telegramAllowlist', ids)
@@ -674,17 +711,43 @@ async function enableTelegram(): Promise<void> {
   telegramServer = new TelegramServer({
     pairing: telegramPairing,
     bridge: telegramBridge(),
+    // Persist relay subscriptions so an app restart doesn't silently drop the
+    // agent→phone relay until the user happens to message the bot again.
+    initialChats: Array.isArray(s.telegramChats) ? s.telegramChats : [],
+    onChatsChange: (ids) => saveSetting('telegramChats', ids),
     onLog: (m) => console.log('[telegram]', m),
     onStatusChange: () => emitTelegramStatus()
   })
 
   try {
     await telegramServer.start(token)
-    saveSetting('telegramEnabled', true)
   } catch (err) {
-    // Bad token / network — tear down and rethrow so the UI can report it.
     telegramServer = null
     telegramPairing = null
+    throw err
+  }
+}
+
+/** Runtime-only teardown — does NOT touch the persisted telegramEnabled flag. */
+async function stopTelegram(): Promise<void> {
+  if (telegramServer) await telegramServer.stop()
+  telegramServer = null
+  telegramPairing = null
+}
+
+async function enableTelegram(): Promise<void> {
+  if (telegramServer) return
+  const token = loadTelegramToken()
+  if (!token) return  // no token yet — UI prompts for one
+  // Upgrade a legacy plaintext token to encrypted storage on first use.
+  if (typeof loadSettings().telegramBotToken === 'string' && safeStorage.isEncryptionAvailable()) {
+    saveTelegramToken(token)
+  }
+  try {
+    await startTelegram(token)
+    saveSetting('telegramEnabled', true)
+  } catch (err) {
+    // Bad token / network — surface to the UI, leave settings as they were.
     emitTelegramStatus()
     throw err
   }
@@ -693,9 +756,7 @@ async function enableTelegram(): Promise<void> {
 
 async function disableTelegram(): Promise<void> {
   saveSetting('telegramEnabled', false)
-  if (telegramServer) await telegramServer.stop()
-  telegramServer = null
-  telegramPairing = null
+  await stopTelegram()
   emitTelegramStatus()
 }
 
@@ -1404,11 +1465,12 @@ function setupMessageNudge(): void {
   hub.messages.onMessageQueued = (msg) => {
     // When an agent messages the user, show an OS notification
     if (msg.to === 'user') {
-      // Mirror it to any linked Telegram chats (Phase 1 relay). No-op when the
-      // bot is off or nobody's paired.
-      telegramServer?.relayFromAgent(msg.from, msg.message)
       const settings = loadSettings()
       if (settings.notifications !== false) {
+        // Mirror it to any linked Telegram chats. No-op when the bot is off or
+        // nobody's paired. Inside the notifications gate on purpose: muting
+        // notifications should silence the phone too, not just the desktop.
+        telegramServer?.relayFromAgent(msg.from, msg.message)
         const preview = msg.message.length > 120 ? msg.message.slice(0, 120) + '…' : msg.message
         const notification = new Notification({
           title: `Message from ${msg.from}`,
@@ -2884,19 +2946,43 @@ function setupIPC(): void {
   ipcMain.handle(IPC.TELEGRAM_ENABLE, async () => { await enableTelegram() })
   ipcMain.handle(IPC.TELEGRAM_DISABLE, async () => { await disableTelegram() })
   ipcMain.handle(IPC.TELEGRAM_SET_TOKEN, async (_e, token: string) => {
-    saveSetting('telegramBotToken', token)
-    // Restart if running so the new token takes effect.
-    if (telegramServer) { await disableTelegram(); await enableTelegram() }
+    const next = typeof token === 'string' ? token.trim() : ''
+    if (next) {
+      // Validate BEFORE persisting so a typo'd paste can't destroy a working
+      // token. validateBotToken only calls getMe — no polling conflict with a
+      // currently-running bot.
+      await validateBotToken(next)  // throws → nothing saved, UI shows the error
+      saveTelegramToken(next)
+      // Restart if running so the new token takes effect.
+      if (telegramServer) { await stopTelegram(); await startTelegram(next) }
+    } else {
+      // Clearing the token shuts the bot down.
+      saveTelegramToken('')
+      await disableTelegram()
+    }
     emitTelegramStatus()
   })
   ipcMain.handle(IPC.TELEGRAM_GET_PAIRING_CODE, async () => {
-    return telegramPairing?.generateCode() ?? null
+    const code = telegramPairing?.generateCode() ?? null
+    emitTelegramStatus()
+    return code
   })
   ipcMain.handle(IPC.TELEGRAM_UNPAIR, async (_e, userId: number) => {
-    telegramPairing?.revoke(userId)
+    if (telegramServer) {
+      // Live bot: cut command access AND the relay subscription in one move.
+      telegramServer.revokeUser(userId)
+    } else {
+      // Bot offline: telegramPairing is null, so edit the persisted lists
+      // directly — otherwise the "removed" user comes back on next enable.
+      const s = loadSettings()
+      const allow = Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist : []
+      saveSetting('telegramAllowlist', allow.filter((id: number) => id !== userId))
+      const chats = Array.isArray(s.telegramChats) ? s.telegramChats : []
+      saveSetting('telegramChats', chats.filter((id: number) => id !== userId))
+    }
     emitTelegramStatus()
   })
-  ipcMain.handle(IPC.TELEGRAM_GET_STATUS, async () => { emitTelegramStatus() })
+  ipcMain.handle(IPC.TELEGRAM_GET_STATUS, async () => telegramStatus())
 
   // Helper: rotate URLs after a token change so both tunnel and LAN URLs reflect the new token
   function rotateUrlsAfterTokenChange(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -648,11 +648,13 @@ function loadTelegramToken(): string {
 
 function telegramStatus(): TelegramStatus {
   const s = loadSettings()
+  const pairedIds = telegramPairing?.list()
+    ?? (Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist : [])
   return {
     enabled: telegramServer?.isRunning() ?? false,
     hasToken: !!loadTelegramToken(),
-    pairedCount: telegramPairing?.size
-      ?? (Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist.length : 0),
+    pairedCount: pairedIds.length,
+    pairedIds,
     activePairingCode: telegramPairing?.getActiveCode() ?? null
   }
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -33,6 +33,8 @@ import { TokenManager } from './remote/token-manager'
 import { CloudflaredManager } from './remote/cloudflared-manager'
 import { RemoteServer } from './remote/remote-server'
 import { RemoteWsHub } from './remote/ws-hub'
+import { PairingManager } from './telegram/pairing-manager'
+import { TelegramServer } from './telegram/telegram-server'
 import * as communityClient from './community/community-client'
 import * as themesStore from './themes/themes-store'
 import * as workspaceThemeStore from './themes/workspace-theme-store'
@@ -96,6 +98,9 @@ let remoteWsHub: RemoteWsHub | null = null
 let remotePublicUrl: string | null = null
 let remoteLanUrl: string | null = null  // http://<lan-ip>:<port>/r/<token>/
 let remoteStatusTicker: ReturnType<typeof setInterval> | null = null
+// Telegram orchestration state
+let telegramServer: TelegramServer | null = null
+let telegramPairing: PairingManager | null = null
 let workshopPasscodeHash: string | null = null
 let cachedWorkspaceState: any = null
 
@@ -605,6 +610,57 @@ async function disableRemoteView(): Promise<void> {
     remoteStatusTicker = null
   }
   emitRemoteStatus()
+}
+
+// ── Telegram orchestration helpers ───────────────────────────────────────────
+
+function emitTelegramStatus(): void {
+  if (!mainWindow) return
+  const s = loadSettings()
+  mainWindow.webContents.send(IPC.TELEGRAM_STATUS_UPDATE, {
+    enabled: telegramServer?.isRunning() ?? false,
+    hasToken: typeof s.telegramBotToken === 'string' && !!s.telegramBotToken,
+    pairedCount: telegramPairing?.size
+      ?? (Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist.length : 0),
+    activePairingCode: telegramPairing?.getActiveCode() ?? null
+  })
+}
+
+async function enableTelegram(): Promise<void> {
+  if (telegramServer) return
+  const s = loadSettings()
+  const token = typeof s.telegramBotToken === 'string' ? s.telegramBotToken.trim() : ''
+  if (!token) return  // no token yet — UI prompts for one
+
+  telegramPairing = new PairingManager({
+    initialAllowlist: Array.isArray(s.telegramAllowlist) ? s.telegramAllowlist : [],
+    onAllowlistChange: (ids) => saveSetting('telegramAllowlist', ids)
+  })
+  telegramServer = new TelegramServer({
+    pairing: telegramPairing,
+    onLog: (m) => console.log('[telegram]', m),
+    onStatusChange: () => emitTelegramStatus()
+  })
+
+  try {
+    await telegramServer.start(token)
+    saveSetting('telegramEnabled', true)
+  } catch (err) {
+    // Bad token / network — tear down and rethrow so the UI can report it.
+    telegramServer = null
+    telegramPairing = null
+    emitTelegramStatus()
+    throw err
+  }
+  emitTelegramStatus()
+}
+
+async function disableTelegram(): Promise<void> {
+  saveSetting('telegramEnabled', false)
+  if (telegramServer) await telegramServer.stop()
+  telegramServer = null
+  telegramPairing = null
+  emitTelegramStatus()
 }
 
 /**
@@ -2785,6 +2841,24 @@ function setupIPC(): void {
     return { ok: true }
   })
 
+  // Telegram orchestration
+  ipcMain.handle(IPC.TELEGRAM_ENABLE, async () => { await enableTelegram() })
+  ipcMain.handle(IPC.TELEGRAM_DISABLE, async () => { await disableTelegram() })
+  ipcMain.handle(IPC.TELEGRAM_SET_TOKEN, async (_e, token: string) => {
+    saveSetting('telegramBotToken', token)
+    // Restart if running so the new token takes effect.
+    if (telegramServer) { await disableTelegram(); await enableTelegram() }
+    emitTelegramStatus()
+  })
+  ipcMain.handle(IPC.TELEGRAM_GET_PAIRING_CODE, async () => {
+    return telegramPairing?.generateCode() ?? null
+  })
+  ipcMain.handle(IPC.TELEGRAM_UNPAIR, async (_e, userId: number) => {
+    telegramPairing?.revoke(userId)
+    emitTelegramStatus()
+  })
+  ipcMain.handle(IPC.TELEGRAM_GET_STATUS, async () => { emitTelegramStatus() })
+
   // Helper: rotate URLs after a token change so both tunnel and LAN URLs reflect the new token
   function rotateUrlsAfterTokenChange(): void {
     if (!remoteTokenManager) return
@@ -2874,6 +2948,12 @@ async function main(): Promise<void> {
     mainWindow?.webContents.send(IPC.UPDATE_AVAILABLE, info)
   }
   updateChecker.start()
+
+  // Telegram orchestration — auto-restore the bot if it was enabled last run.
+  // Mirrors the bot's own lifecycle: a missing/blank token is a no-op.
+  if (loadSettings().telegramEnabled) {
+    enableTelegram().catch((e) => console.error('[telegram] auto-start failed:', e))
+  }
 
   // Auto-open last project, or let renderer show project picker
   const lastProject = projectManager.getLastProject()

--- a/src/main/streamdeck/index.ts
+++ b/src/main/streamdeck/index.ts
@@ -196,7 +196,7 @@ export async function reconnectStreamDeck(opts: InitOpts): Promise<void> {
   await initStreamDeck(opts)
 }
 
-function buildWhisperClient(settings: { whisperBackend: string; openaiApiKey?: string }): WhisperClient | null {
+export function buildWhisperClient(settings: { whisperBackend: string; openaiApiKey?: string }): WhisperClient | null {
   if (settings.whisperBackend === 'cloud') {
     const key = settings.openaiApiKey || process.env.OPENAI_API_KEY || ''
     return new CloudWhisperClient({ apiKey: key })

--- a/src/main/telegram/ansi.test.ts
+++ b/src/main/telegram/ansi.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { stripAnsi } from './ansi'
+
+describe('stripAnsi', () => {
+  it('removes SGR color sequences', () => {
+    expect(stripAnsi('\x1b[38;5;12mhello\x1b[0m world')).toBe('hello world')
+  })
+
+  it('removes cursor-control and erase sequences', () => {
+    expect(stripAnsi('\x1b[2K\x1b[1Gprompt> done')).toBe('prompt> done')
+  })
+
+  it('removes OSC title/hyperlink sequences', () => {
+    expect(stripAnsi('\x1b]0;my title\x07text')).toBe('text')
+    expect(stripAnsi('\x1b]8;;https://x.test\x1b\\link\x1b]8;;\x1b\\')).toBe('link')
+  })
+
+  it('removes charset designations and carriage returns', () => {
+    expect(stripAnsi('\x1b(Bspinner\r')).toBe('spinner')
+  })
+
+  it('keeps newlines, tabs, and plain text untouched', () => {
+    expect(stripAnsi('a\tb\nplain')).toBe('a\tb\nplain')
+  })
+})

--- a/src/main/telegram/ansi.ts
+++ b/src/main/telegram/ansi.ts
@@ -1,0 +1,20 @@
+/**
+ * Strip ANSI/VT escape sequences and cursor-control noise from raw PTY output
+ * so it reads as plain text in a Telegram message. The OutputBuffer stores
+ * terminal bytes verbatim (CLI agents like Claude Code emit heavy CSI/OSC
+ * traffic); every display surface strips before rendering — Remote View does
+ * this in the browser, this is the main-process equivalent for the bot.
+ */
+
+// CSI: ESC [ params… intermediates… final   (colors, cursor moves, erases)
+const CSI = /\x1b\[[0-9:;<=>?]*[ !"#$%&'()*+,\-./]*[@-~]/g
+// OSC: ESC ] … BEL | ESC \                  (window titles, hyperlinks)
+const OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?/g
+// Charset designation and other two-byte escapes: ESC ( B, ESC = , ESC 7 …
+const TWO_BYTE = /\x1b[()][0-9A-Za-z]|\x1b[@-Z\\-_=><~]/g
+// Remaining C0 control chars except \n and \t (kills \r, backspace, BEL…)
+const CONTROL = /[\x00-\x08\x0b-\x1f\x7f]/g
+
+export function stripAnsi(text: string): string {
+  return text.replace(CSI, '').replace(OSC, '').replace(TWO_BYTE, '').replace(CONTROL, '')
+}

--- a/src/main/telegram/attachment.test.ts
+++ b/src/main/telegram/attachment.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { extensionOf, isTextFile, sanitizeFilename, buildAttachmentMessage } from './attachment'
+
+describe('extensionOf', () => {
+  it('pulls the extension, lowercased', () => {
+    expect(extensionOf('Notes.MD')).toBe('md')
+    expect(extensionOf('a/b/c/report.txt')).toBe('txt')
+  })
+  it('treats a dotfile name as its own extension', () => {
+    expect(extensionOf('.gitignore')).toBe('gitignore')
+    expect(extensionOf('Makefile')).toBe('makefile')
+  })
+})
+
+describe('isTextFile', () => {
+  it('accepts known text extensions', () => {
+    expect(isTextFile('notes.md')).toBe(true)
+    expect(isTextFile('data.json')).toBe(true)
+    expect(isTextFile('script.py')).toBe(true)
+  })
+  it('rejects images and binaries by extension', () => {
+    expect(isTextFile('photo.jpg')).toBe(false)
+    expect(isTextFile('archive.zip')).toBe(false)
+  })
+  it('trusts mime type over extension when decisive', () => {
+    expect(isTextFile('weird.bin', 'text/plain')).toBe(true)
+    expect(isTextFile('notes.md', 'image/png')).toBe(false)  // image mime wins
+  })
+})
+
+describe('sanitizeFilename', () => {
+  it('strips directory traversal to a bare basename', () => {
+    expect(sanitizeFilename('../../etc/passwd')).toBe('passwd')
+    expect(sanitizeFilename('C:\\Windows\\evil.txt')).toBe('evil.txt')
+  })
+  it('drops leading dots and illegal characters', () => {
+    expect(sanitizeFilename('...hidden')).toBe('hidden')
+    expect(sanitizeFilename('a<b>c:d?.txt')).toBe('abcd.txt')
+  })
+  it('falls back when nothing usable remains', () => {
+    expect(sanitizeFilename('///')).toBe('telegram-file')
+    expect(sanitizeFilename('', 'photo.jpg')).toBe('photo.jpg')
+  })
+})
+
+describe('buildAttachmentMessage', () => {
+  it('inlines text content and notes truncation', () => {
+    const msg = buildAttachmentMessage({
+      filename: 'notes.md', relPath: '.cog/telegram-inbox/notes.md',
+      isImage: false, textContent: '# Hello', truncated: true, caption: 'read this'
+    })
+    expect(msg).toContain('📎 Telegram sent a file: notes.md')
+    expect(msg).toContain('Saved to: .cog/telegram-inbox/notes.md')
+    expect(msg).toContain('Caption: read this')
+    expect(msg).toContain('# Hello')
+    expect(msg).toContain('Truncated')
+  })
+  it('points an image at its path instead of inlining', () => {
+    const msg = buildAttachmentMessage({
+      filename: 'shot.png', relPath: '.cog/telegram-inbox/shot.png',
+      isImage: true, textContent: null
+    })
+    expect(msg).toContain('📎 Telegram sent an image: shot.png')
+    expect(msg).toContain('Open/read .cog/telegram-inbox/shot.png')
+    expect(msg).not.toContain('--- end ---')
+  })
+})

--- a/src/main/telegram/attachment.test.ts
+++ b/src/main/telegram/attachment.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { extensionOf, isTextFile, sanitizeFilename, buildAttachmentMessage } from './attachment'
+import { extensionOf, isTextFile, isImageFile, sanitizeFilename, buildAttachmentMessage } from './attachment'
 
 describe('extensionOf', () => {
   it('pulls the extension, lowercased', () => {
@@ -25,6 +25,18 @@ describe('isTextFile', () => {
   it('trusts mime type over extension when decisive', () => {
     expect(isTextFile('weird.bin', 'text/plain')).toBe(true)
     expect(isTextFile('notes.md', 'image/png')).toBe(false)  // image mime wins
+  })
+})
+
+describe('isImageFile', () => {
+  it('detects images by mime or extension', () => {
+    expect(isImageFile('shot.png')).toBe(true)
+    expect(isImageFile('pic.JPG')).toBe(true)
+    expect(isImageFile('blob', 'image/webp')).toBe(true)
+  })
+  it('is false for non-images (incl. svg, which we treat as text)', () => {
+    expect(isImageFile('notes.md')).toBe(false)
+    expect(isImageFile('diagram.svg')).toBe(false)
   })
 })
 

--- a/src/main/telegram/attachment.ts
+++ b/src/main/telegram/attachment.ts
@@ -1,0 +1,89 @@
+/**
+ * Pure helpers for turning a Telegram attachment into something an agent can
+ * actually consume. No fs, no grammY — just decisions about text-vs-binary,
+ * safe filenames, and the message body the agent receives. Kept separate from
+ * the download/save I/O so the rules are unit-testable.
+ */
+
+// How much file text to inline into the agent message before we truncate. Kept
+// well under the hub's 10 KB per-message cap so the wrapper always fits; the
+// full file is on disk regardless, so the agent can read past this.
+export const TEXT_INLINE_LIMIT = 8_000
+
+// Extensions we treat as inline-able text. Everything else (images, pdfs,
+// archives, binaries) is saved to disk and handed to the agent as a path.
+const TEXT_EXTENSIONS = new Set([
+  'txt', 'md', 'markdown', 'rst', 'log', 'csv', 'tsv',
+  'json', 'jsonl', 'yaml', 'yml', 'toml', 'xml', 'ini', 'cfg', 'conf', 'env',
+  'html', 'htm', 'css', 'scss', 'svg',
+  'js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs', 'py', 'rb', 'go', 'rs', 'java',
+  'c', 'h', 'cpp', 'hpp', 'cc', 'cs', 'php', 'swift', 'kt', 'scala',
+  'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'sql', 'diff', 'patch',
+  'gitignore', 'dockerfile', 'makefile', 'gradle', 'properties'
+])
+
+export function extensionOf(filename: string): string {
+  const base = filename.split(/[\\/]/).pop() ?? filename
+  const dot = base.lastIndexOf('.')
+  // No dot, or leading-dot-only (e.g. ".gitignore") → treat whole name as ext.
+  if (dot <= 0) return base.replace(/^\./, '').toLowerCase()
+  return base.slice(dot + 1).toLowerCase()
+}
+
+/** Is this something we can meaningfully inline as UTF-8 text? */
+export function isTextFile(filename: string, mimeType?: string): boolean {
+  if (mimeType) {
+    if (mimeType.startsWith('text/')) return true
+    if (mimeType === 'application/json' || mimeType === 'application/xml') return true
+    if (mimeType.startsWith('image/') || mimeType === 'application/pdf') return false
+  }
+  return TEXT_EXTENSIONS.has(extensionOf(filename))
+}
+
+/**
+ * Strip a Telegram-supplied filename down to a safe basename: no directory
+ * traversal, no separators, bounded length, never empty. The sender is the
+ * trusted owner, but a filename like "../../etc/passwd" must never escape the
+ * inbox folder.
+ */
+export function sanitizeFilename(name: string, fallback = 'telegram-file'): string {
+  const base = (name.split(/[\\/]/).pop() ?? '').trim()
+  const cleaned = base
+    .replace(/[\x00-\x1f<>:"|?*]/g, '')  // control + Windows-illegal chars
+    .replace(/^\.+/, '')                  // no leading dots ("..", hidden traversal)
+    .slice(0, 120)
+    .trim()
+  return cleaned || fallback
+}
+
+export interface AttachmentMessageInput {
+  filename: string
+  /** Path the agent can open, relative to its cwd (the project root). */
+  relPath: string
+  caption?: string
+  isImage: boolean
+  /** Decoded text, already truncated to the inline limit (null for binary). */
+  textContent?: string | null
+  /** True when textContent was cut off — the full file is still on disk. */
+  truncated?: boolean
+}
+
+/** Build the hub message an agent receives for an incoming attachment. */
+export function buildAttachmentMessage(input: AttachmentMessageInput): string {
+  const { filename, relPath, caption, isImage, textContent, truncated } = input
+  const head = isImage
+    ? `📎 Telegram sent an image: ${filename}`
+    : `📎 Telegram sent a file: ${filename}`
+  const lines = [head, `Saved to: ${relPath}`]
+  if (caption && caption.trim()) lines.push(`Caption: ${caption.trim()}`)
+
+  if (textContent != null) {
+    lines.push('', `--- ${filename} ---`, textContent, '--- end ---')
+    if (truncated) lines.push(`(Truncated — read ${relPath} for the full contents.)`)
+  } else if (isImage) {
+    lines.push('', `Open/read ${relPath} to view the image.`)
+  } else {
+    lines.push('', `Read ${relPath} to inspect the file.`)
+  }
+  return lines.join('\n')
+}

--- a/src/main/telegram/attachment.ts
+++ b/src/main/telegram/attachment.ts
@@ -10,6 +10,10 @@
 // full file is on disk regardless, so the agent can read past this.
 export const TEXT_INLINE_LIMIT = 8_000
 
+// Captions are also inlined, so bound them too: 8000 + 1000 + wrapper stays
+// under the hub's 10240-char message ceiling (Telegram Premium allows 2048).
+const CAPTION_LIMIT = 1_000
+
 // Extensions we treat as inline-able text. Everything else (images, pdfs,
 // archives, binaries) is saved to disk and handed to the agent as a path.
 const TEXT_EXTENSIONS = new Set([
@@ -28,6 +32,14 @@ export function extensionOf(filename: string): string {
   // No dot, or leading-dot-only (e.g. ".gitignore") → treat whole name as ext.
   if (dot <= 0) return base.replace(/^\./, '').toLowerCase()
   return base.slice(dot + 1).toLowerCase()
+}
+
+const IMAGE_EXTENSIONS = /\.(jpe?g|png|gif|webp|bmp|heic|heif)$/i
+
+/** Is this an image (so we hand the agent a path to open rather than inlining)? */
+export function isImageFile(filename: string, mimeType?: string): boolean {
+  if (mimeType?.startsWith('image/')) return true
+  return IMAGE_EXTENSIONS.test(filename)
 }
 
 /** Is this something we can meaningfully inline as UTF-8 text? */
@@ -75,7 +87,7 @@ export function buildAttachmentMessage(input: AttachmentMessageInput): string {
     ? `📎 Telegram sent an image: ${filename}`
     : `📎 Telegram sent a file: ${filename}`
   const lines = [head, `Saved to: ${relPath}`]
-  if (caption && caption.trim()) lines.push(`Caption: ${caption.trim()}`)
+  if (caption && caption.trim()) lines.push(`Caption: ${caption.trim().slice(0, CAPTION_LIMIT)}`)
 
   if (textContent != null) {
     lines.push('', `--- ${filename} ---`, textContent, '--- end ---')

--- a/src/main/telegram/bridge.ts
+++ b/src/main/telegram/bridge.ts
@@ -23,6 +23,13 @@ export interface IncomingFile {
   caption?: string
 }
 
+/** A voice note forwarded from Telegram, already downloaded to memory. */
+export interface IncomingVoice {
+  bytes: Uint8Array
+  mimeType?: string   // typically audio/ogg (opus)
+  caption?: string
+}
+
 /** A team/schedule proposal, flattened for the bot (decoupled from shared types). */
 export interface ProposalView {
   id: string
@@ -44,6 +51,12 @@ export interface OrchestratorBridge {
    * can open. Returns the saved path (relative to the project) on success.
    */
   sendFile(name: string, file: IncomingFile): { ok: boolean; relPath?: string; detail?: string }
+  /**
+   * Transcribe a voice note (via the app's configured Whisper backend) and route
+   * the text to a named agent. Falls back to saving the audio if transcription
+   * is unavailable. Returns the transcript when one was produced.
+   */
+  sendVoice(name: string, voice: IncomingVoice): Promise<{ ok: boolean; transcript?: string; detail?: string }>
   /** Recent terminal output lines for a named agent (newest last). */
   getOutput(name: string, lines: number): string[]
   /** Post a task to the shared pinboard. */

--- a/src/main/telegram/bridge.ts
+++ b/src/main/telegram/bridge.ts
@@ -15,11 +15,25 @@ export interface TelegramTarget {
   status: string  // 'active' | 'idle' | 'thinking' | 'disconnected' | …
 }
 
+/** A file or photo forwarded from Telegram, already downloaded to memory. */
+export interface IncomingFile {
+  filename: string
+  bytes: Uint8Array
+  mimeType?: string
+  caption?: string
+}
+
 export interface OrchestratorBridge {
   /** Live addressable agents (the registry minus the 'user' pseudo-agent). */
   listTargets(): TelegramTarget[]
   /** Route text into a named agent's inbox. Mirrors a user→agent hub message. */
   sendTo(name: string, text: string): { ok: boolean; detail?: string }
+  /**
+   * Save an incoming attachment into the project and route it to a named agent:
+   * text files are inlined, images/binaries are handed over as a path the agent
+   * can open. Returns the saved path (relative to the project) on success.
+   */
+  sendFile(name: string, file: IncomingFile): { ok: boolean; relPath?: string; detail?: string }
   /** Recent terminal output lines for a named agent (newest last). */
   getOutput(name: string, lines: number): string[]
   /** Post a task to the shared pinboard. */

--- a/src/main/telegram/bridge.ts
+++ b/src/main/telegram/bridge.ts
@@ -23,6 +23,16 @@ export interface IncomingFile {
   caption?: string
 }
 
+/** A team/schedule proposal, flattened for the bot (decoupled from shared types). */
+export interface ProposalView {
+  id: string
+  proposedBy: string
+  summary: string
+  kind: 'team' | 'schedule'
+  status: 'pending' | 'approved' | 'rejected' | 'expired'
+  agents: { name: string; role: string; cli: string; model?: string; notes?: string }[]
+}
+
 export interface OrchestratorBridge {
   /** Live addressable agents (the registry minus the 'user' pseudo-agent). */
   listTargets(): TelegramTarget[]
@@ -38,4 +48,10 @@ export interface OrchestratorBridge {
   getOutput(name: string, lines: number): string[]
   /** Post a task to the shared pinboard. */
   postTask(title: string): { ok: boolean; id?: string; detail?: string }
+  /** Approve a pending team/schedule proposal (spawns agents / creates schedule). */
+  approveProposal(id: string): Promise<{ ok: boolean; detail?: string }>
+  /** Reject a pending proposal. */
+  rejectProposal(id: string): Promise<{ ok: boolean; detail?: string }>
+  /** Fetch a proposal's current view, or null if it's gone. */
+  getProposal(id: string): ProposalView | null
 }

--- a/src/main/telegram/bridge.ts
+++ b/src/main/telegram/bridge.ts
@@ -1,0 +1,27 @@
+/**
+ * The seam between the Telegram bot and The Cog's orchestration hub.
+ *
+ * telegram-server.ts speaks only this interface — it never imports the hub,
+ * the registry, or electron. index.ts supplies a concrete implementation
+ * backed by hub.messages / hub.registry / hub.pinboard / the PTY buffers.
+ * Same decoupling philosophy as PairingManager: the bot stays unit-testable
+ * and the hub stays the single source of truth.
+ */
+
+/** An agent the bot can address — one "head" of the dragon. */
+export interface TelegramTarget {
+  name: string
+  role: string    // 'orchestrator' | 'worker' | 'researcher' | …
+  status: string  // 'active' | 'idle' | 'thinking' | 'disconnected' | …
+}
+
+export interface OrchestratorBridge {
+  /** Live addressable agents (the registry minus the 'user' pseudo-agent). */
+  listTargets(): TelegramTarget[]
+  /** Route text into a named agent's inbox. Mirrors a user→agent hub message. */
+  sendTo(name: string, text: string): { ok: boolean; detail?: string }
+  /** Recent terminal output lines for a named agent (newest last). */
+  getOutput(name: string, lines: number): string[]
+  /** Post a task to the shared pinboard. */
+  postTask(title: string): { ok: boolean; id?: string; detail?: string }
+}

--- a/src/main/telegram/chat-router.test.ts
+++ b/src/main/telegram/chat-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { ChatRouter } from './chat-router'
 import type { TelegramTarget } from './bridge'
 
@@ -75,5 +75,24 @@ describe('ChatRouter', () => {
   it('returns null effective target when there are no targets', () => {
     const r = new ChatRouter()
     expect(r.effectiveTarget(1, [])).toBeNull()
+  })
+
+  it('seeds subscriptions from initialSubscribed (restart survival)', () => {
+    const r = new ChatRouter({ initialSubscribed: [7, 8] })
+    expect(r.isSubscribed(7)).toBe(true)
+    expect(r.subscribedChats().sort()).toEqual([7, 8])
+  })
+
+  it('reports subscription changes so the caller can persist them', () => {
+    const onChange = vi.fn()
+    const r = new ChatRouter({ onSubscribedChange: onChange })
+    r.subscribe(1)
+    expect(onChange).toHaveBeenLastCalledWith([1])
+    r.subscribe(1)                       // idempotent — no re-fire
+    expect(onChange).toHaveBeenCalledTimes(1)
+    r.forget(1)
+    expect(onChange).toHaveBeenLastCalledWith([])
+    r.forget(1)                          // already gone — no re-fire
+    expect(onChange).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/main/telegram/chat-router.test.ts
+++ b/src/main/telegram/chat-router.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { ChatRouter } from './chat-router'
+import type { TelegramTarget } from './bridge'
+
+const t = (name: string, role = 'worker', status = 'idle'): TelegramTarget => ({ name, role, status })
+
+describe('ChatRouter', () => {
+  it('subscribes chats idempotently and lists them', () => {
+    const r = new ChatRouter()
+    expect(r.isSubscribed(1)).toBe(false)
+    r.subscribe(1)
+    r.subscribe(1)
+    r.subscribe(2)
+    expect(r.isSubscribed(1)).toBe(true)
+    expect(r.subscribedChats().sort()).toEqual([1, 2])
+  })
+
+  it('forgets a chat completely', () => {
+    const r = new ChatRouter()
+    r.subscribe(1)
+    r.setActive(1, 'cara')
+    r.forget(1)
+    expect(r.isSubscribed(1)).toBe(false)
+    expect(r.getActive(1)).toBeNull()
+  })
+
+  it('resolves an exact name case-insensitively', () => {
+    const r = new ChatRouter()
+    const targets = [t('Cara', 'orchestrator'), t('Dax', 'orchestrator')]
+    expect(r.resolveTarget('cara', targets)?.name).toBe('Cara')
+    expect(r.resolveTarget('DAX', targets)?.name).toBe('Dax')
+  })
+
+  it('resolves a unique prefix but rejects an ambiguous one', () => {
+    const r = new ChatRouter()
+    const targets = [t('Cara', 'orchestrator'), t('Carl', 'worker'), t('Dax', 'orchestrator')]
+    expect(r.resolveTarget('d', targets)?.name).toBe('Dax')   // unique prefix
+    expect(r.resolveTarget('car', targets)).toBeNull()         // Cara vs Carl — ambiguous
+    expect(r.resolveTarget('zzz', targets)).toBeNull()         // no match
+  })
+
+  it('prefers a live orchestrator as the default target', () => {
+    const r = new ChatRouter()
+    const targets = [
+      t('Wendy', 'worker', 'active'),
+      t('Cara', 'orchestrator', 'disconnected'),
+      t('Dax', 'orchestrator', 'idle')
+    ]
+    expect(r.pickDefault(targets)?.name).toBe('Dax')
+  })
+
+  it('falls back to any orchestrator, then any live agent', () => {
+    const r = new ChatRouter()
+    expect(r.pickDefault([t('Cara', 'orchestrator', 'disconnected'), t('Wendy', 'worker', 'active')])?.name)
+      .toBe('Cara')  // disconnected orchestrator still beats a worker
+    expect(r.pickDefault([t('A', 'worker', 'disconnected'), t('B', 'worker', 'idle')])?.name)
+      .toBe('B')     // no orchestrator → first live agent
+    expect(r.pickDefault([])).toBeNull()
+  })
+
+  it('uses the remembered active target when it is still present', () => {
+    const r = new ChatRouter()
+    const targets = [t('Cara', 'orchestrator'), t('Dax', 'orchestrator')]
+    r.setActive(99, 'Dax')
+    expect(r.effectiveTarget(99, targets)?.name).toBe('Dax')
+  })
+
+  it('falls back to the default when the remembered target vanished', () => {
+    const r = new ChatRouter()
+    r.setActive(99, 'Ghost')
+    const targets = [t('Cara', 'orchestrator', 'idle')]
+    expect(r.effectiveTarget(99, targets)?.name).toBe('Cara')
+  })
+
+  it('returns null effective target when there are no targets', () => {
+    const r = new ChatRouter()
+    expect(r.effectiveTarget(1, [])).toBeNull()
+  })
+})

--- a/src/main/telegram/chat-router.ts
+++ b/src/main/telegram/chat-router.ts
@@ -1,5 +1,12 @@
 import type { TelegramTarget } from './bridge'
 
+export interface ChatRouterOptions {
+  /** Chats already subscribed to the relay (loaded from settings on boot). */
+  initialSubscribed?: number[]
+  /** Fired whenever the subscription set changes so the caller can persist it. */
+  onSubscribedChange?: (chatIds: number[]) => void
+}
+
 /**
  * Per-chat routing state — the "sub-groups" / multi-dragon addressing layer.
  *
@@ -20,12 +27,20 @@ import type { TelegramTarget } from './bridge'
  *    we fall back to a sensible default (prefer a live orchestrator).
  */
 export class ChatRouter {
-  private subscribed = new Set<number>()
+  private subscribed: Set<number>
   private activeByChat = new Map<number, string>()
+  private readonly onSubscribedChange?: (chatIds: number[]) => void
+
+  constructor(opts: ChatRouterOptions = {}) {
+    this.subscribed = new Set(opts.initialSubscribed ?? [])
+    this.onSubscribedChange = opts.onSubscribedChange
+  }
 
   /** Mark a chat as a relay destination (idempotent). */
   subscribe(chatId: number): void {
+    if (this.subscribed.has(chatId)) return
     this.subscribed.add(chatId)
+    this.onSubscribedChange?.(this.subscribedChats())
   }
 
   isSubscribed(chatId: number): boolean {
@@ -37,8 +52,9 @@ export class ChatRouter {
   }
 
   forget(chatId: number): void {
-    this.subscribed.delete(chatId)
+    const had = this.subscribed.delete(chatId)
     this.activeByChat.delete(chatId)
+    if (had) this.onSubscribedChange?.(this.subscribedChats())
   }
 
   /** Pin this chat's active target by exact agent name. */

--- a/src/main/telegram/chat-router.ts
+++ b/src/main/telegram/chat-router.ts
@@ -1,0 +1,98 @@
+import type { TelegramTarget } from './bridge'
+
+/**
+ * Per-chat routing state — the "sub-groups" / multi-dragon addressing layer.
+ *
+ * The Cog can run more than one orchestrator (the "double-headed dragon"), plus
+ * workers and MCP-backed agents. A single Telegram chat needs to know *which*
+ * head it's currently talking to, and which chats want orchestrator output
+ * pushed back to them.
+ *
+ * This class is pure routing bookkeeping — no grammY, no hub, no I/O — so the
+ * addressing rules (resolution, default selection, active-target memory) are
+ * trivially unit-testable, exactly like PairingManager.
+ *
+ * Model:
+ *  - A chat becomes *subscribed* the first time a trusted user interacts with
+ *    it; subscribed chats receive relayed agent output.
+ *  - Each chat remembers an *active target*. Plain text routes there. `/use`
+ *    switches it. If the remembered target is gone (agent disconnected/renamed),
+ *    we fall back to a sensible default (prefer a live orchestrator).
+ */
+export class ChatRouter {
+  private subscribed = new Set<number>()
+  private activeByChat = new Map<number, string>()
+
+  /** Mark a chat as a relay destination (idempotent). */
+  subscribe(chatId: number): void {
+    this.subscribed.add(chatId)
+  }
+
+  isSubscribed(chatId: number): boolean {
+    return this.subscribed.has(chatId)
+  }
+
+  subscribedChats(): number[] {
+    return Array.from(this.subscribed)
+  }
+
+  forget(chatId: number): void {
+    this.subscribed.delete(chatId)
+    this.activeByChat.delete(chatId)
+  }
+
+  /** Pin this chat's active target by exact agent name. */
+  setActive(chatId: number, name: string): void {
+    this.activeByChat.set(chatId, name)
+  }
+
+  /** Raw remembered target name, if any (may be stale). */
+  getActive(chatId: number): string | null {
+    return this.activeByChat.get(chatId) ?? null
+  }
+
+  /**
+   * Resolve a user-typed target name against the live target list:
+   *   1. exact match (case-insensitive)
+   *   2. unique prefix match (case-insensitive) — lets you type `/use ca` for "Cara"
+   * Returns null if nothing matches or a prefix is ambiguous.
+   */
+  resolveTarget(input: string, targets: TelegramTarget[]): TelegramTarget | null {
+    const q = input.trim().toLowerCase()
+    if (!q) return null
+
+    const exact = targets.find(t => t.name.toLowerCase() === q)
+    if (exact) return exact
+
+    const prefixed = targets.filter(t => t.name.toLowerCase().startsWith(q))
+    return prefixed.length === 1 ? prefixed[0] : null
+  }
+
+  /**
+   * Default target when a chat hasn't chosen one: prefer a non-disconnected
+   * orchestrator, then any orchestrator, then any live agent, then anything.
+   */
+  pickDefault(targets: TelegramTarget[]): TelegramTarget | null {
+    if (targets.length === 0) return null
+    const liveOrch = targets.find(t => t.role === 'orchestrator' && t.status !== 'disconnected')
+    if (liveOrch) return liveOrch
+    const anyOrch = targets.find(t => t.role === 'orchestrator')
+    if (anyOrch) return anyOrch
+    const live = targets.find(t => t.status !== 'disconnected')
+    return live ?? targets[0]
+  }
+
+  /**
+   * The target plain text should route to for this chat: the remembered active
+   * target if it's still present, otherwise the default. Returns null only when
+   * there are no targets at all.
+   */
+  effectiveTarget(chatId: number, targets: TelegramTarget[]): TelegramTarget | null {
+    const activeName = this.activeByChat.get(chatId)
+    if (activeName) {
+      const match = targets.find(t => t.name === activeName)
+      if (match) return match
+    }
+    return this.pickDefault(targets)
+  }
+}

--- a/src/main/telegram/pairing-manager.test.ts
+++ b/src/main/telegram/pairing-manager.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PairingManager } from './pairing-manager'
+
+describe('PairingManager', () => {
+  it('pairs a user with a valid code and persists the change', () => {
+    const onChange = vi.fn()
+    const pm = new PairingManager({ onAllowlistChange: onChange })
+    const code = pm.generateCode()
+    expect(code).toMatch(/^\d{6}$/)
+    expect(pm.tryPair(42, code)).toBe(true)
+    expect(pm.isAllowed(42)).toBe(true)
+    expect(onChange).toHaveBeenCalledWith([42])
+  })
+
+  it('rejects a wrong code without trusting the user', () => {
+    const pm = new PairingManager()
+    const code = pm.generateCode()
+    const wrong = code === '000000' ? '000001' : '000000'  // guaranteed different
+    expect(pm.tryPair(42, wrong)).toBe(false)
+    expect(pm.isAllowed(42)).toBe(false)
+  })
+
+  it('consumes the code so it cannot be reused', () => {
+    const pm = new PairingManager()
+    const code = pm.generateCode()
+    expect(pm.tryPair(1, code)).toBe(true)
+    expect(pm.tryPair(2, code)).toBe(false)
+    expect(pm.isAllowed(2)).toBe(false)
+  })
+
+  it('expires codes after the TTL using the injected clock', () => {
+    let now = 0
+    const pm = new PairingManager({ clock: () => now, codeTtlMs: 1000 })
+    const code = pm.generateCode()
+    now = 1001
+    expect(pm.getActiveCode()).toBeNull()
+    expect(pm.tryPair(7, code)).toBe(false)
+  })
+
+  it('revokes a trusted user and reports the change', () => {
+    const onChange = vi.fn()
+    const pm = new PairingManager({ initialAllowlist: [5], onAllowlistChange: onChange })
+    expect(pm.isAllowed(5)).toBe(true)
+    expect(pm.revoke(5)).toBe(true)
+    expect(pm.isAllowed(5)).toBe(false)
+    expect(onChange).toHaveBeenLastCalledWith([])
+  })
+
+  it('ignores undefined user IDs', () => {
+    const pm = new PairingManager({ initialAllowlist: [1] })
+    expect(pm.isAllowed(undefined)).toBe(false)
+  })
+})

--- a/src/main/telegram/pairing-manager.test.ts
+++ b/src/main/telegram/pairing-manager.test.ts
@@ -50,4 +50,27 @@ describe('PairingManager', () => {
     const pm = new PairingManager({ initialAllowlist: [1] })
     expect(pm.isAllowed(undefined)).toBe(false)
   })
+
+  it('burns the code after too many failed attempts (anti-brute-force)', () => {
+    const pm = new PairingManager({ maxAttempts: 3 })
+    const code = pm.generateCode()
+    const wrong = code === '000000' ? '000001' : '000000'
+    for (let i = 0; i < 3; i++) expect(pm.tryPair(9, wrong)).toBe(false)
+    // Code is now burned — even the real one no longer works.
+    expect(pm.getActiveCode()).toBeNull()
+    expect(pm.tryPair(9, code)).toBe(false)
+    expect(pm.isAllowed(9)).toBe(false)
+  })
+
+  it('resets the failure counter when a fresh code is generated', () => {
+    const pm = new PairingManager({ maxAttempts: 3 })
+    let code = pm.generateCode()
+    const wrong = code === '000000' ? '000001' : '000000'
+    pm.tryPair(9, wrong)
+    pm.tryPair(9, wrong)
+    code = pm.generateCode()  // fresh code → fresh budget
+    pm.tryPair(9, code === '000000' ? '000001' : '000000')
+    pm.tryPair(9, code === '000000' ? '000001' : '000000')
+    expect(pm.tryPair(9, code)).toBe(true)  // 2 failures < 3, still valid
+  })
 })

--- a/src/main/telegram/pairing-manager.ts
+++ b/src/main/telegram/pairing-manager.ts
@@ -1,0 +1,110 @@
+import { randomInt, timingSafeEqual } from 'crypto'
+
+const DEFAULT_CODE_TTL_MS = 10 * 60 * 1000   // pairing codes expire after 10 min
+
+export interface PairingManagerOptions {
+  /** Telegram user IDs already trusted (loaded from settings on boot). */
+  initialAllowlist?: number[]
+  /** Fired whenever the allowlist changes so the caller can persist it. */
+  onAllowlistChange?: (ids: number[]) => void
+  /** Injectable clock for testing. */
+  clock?: () => number
+  /** How long a freshly generated pairing code stays valid. */
+  codeTtlMs?: number
+}
+
+/**
+ * Owns Telegram auth for The Cog: a one-time pairing code (the ownership
+ * proof — same mental model as the Remote View passcode) and the allowlist of
+ * trusted Telegram user IDs. The bot answers nobody until they pair.
+ *
+ * Mirrors remote/token-manager.ts: in-memory state, timing-safe compares,
+ * clock DI. Persistence is delegated to the caller via onAllowlistChange so
+ * this file stays free of fs/electron concerns and is trivially unit-testable.
+ */
+export class PairingManager {
+  private allowlist: Set<number>
+  private pendingCode: string | null = null
+  private codeExpiresAt: number | null = null
+  private readonly onChange?: (ids: number[]) => void
+  private readonly clock: () => number
+  private readonly codeTtlMs: number
+
+  constructor(opts: PairingManagerOptions = {}) {
+    this.allowlist = new Set(opts.initialAllowlist ?? [])
+    this.onChange = opts.onAllowlistChange
+    this.clock = opts.clock ?? Date.now
+    this.codeTtlMs = opts.codeTtlMs ?? DEFAULT_CODE_TTL_MS
+  }
+
+  /** Generate a fresh 6-digit pairing code, replacing any previous one. */
+  generateCode(): string {
+    const n = randomInt(0, 1_000_000)
+    this.pendingCode = n.toString().padStart(6, '0')
+    this.codeExpiresAt = this.clock() + this.codeTtlMs
+    return this.pendingCode
+  }
+
+  /** The active code if one exists and hasn't expired, else null. */
+  getActiveCode(): string | null {
+    if (this.pendingCode === null || this.codeExpiresAt === null) return null
+    if (this.clock() > this.codeExpiresAt) {
+      this.pendingCode = null
+      this.codeExpiresAt = null
+      return null
+    }
+    return this.pendingCode
+  }
+
+  /**
+   * Attempt to pair a Telegram user with the given code. On success the user
+   * is added to the allowlist and the code is consumed (single-use).
+   */
+  tryPair(userId: number, code: string): boolean {
+    const active = this.getActiveCode()
+    if (active === null) return false
+    if (typeof code !== 'string') return false
+    // Constant-time compare so the bot can't be used as a timing oracle.
+    const a = Buffer.from(code)
+    const b = Buffer.from(active)
+    if (a.length !== b.length) return false
+    if (!timingSafeEqual(a, b)) return false
+    // Consume the code so it can't be replayed, then trust the user.
+    this.pendingCode = null
+    this.codeExpiresAt = null
+    if (!this.allowlist.has(userId)) {
+      this.allowlist.add(userId)
+      this.onChange?.(this.list())
+    }
+    return true
+  }
+
+  isAllowed(userId: number | undefined): boolean {
+    if (typeof userId !== 'number') return false
+    return this.allowlist.has(userId)
+  }
+
+  /** Remove a user from the allowlist. Returns true if they were present. */
+  revoke(userId: number): boolean {
+    const had = this.allowlist.delete(userId)
+    if (had) this.onChange?.(this.list())
+    return had
+  }
+
+  /** Drop every trusted user and any pending code (panic / reset). */
+  revokeAll(): void {
+    const had = this.allowlist.size > 0
+    this.allowlist.clear()
+    this.pendingCode = null
+    this.codeExpiresAt = null
+    if (had) this.onChange?.(this.list())
+  }
+
+  list(): number[] {
+    return Array.from(this.allowlist)
+  }
+
+  get size(): number {
+    return this.allowlist.size
+  }
+}

--- a/src/main/telegram/pairing-manager.ts
+++ b/src/main/telegram/pairing-manager.ts
@@ -1,6 +1,7 @@
 import { randomInt, timingSafeEqual } from 'crypto'
 
 const DEFAULT_CODE_TTL_MS = 10 * 60 * 1000   // pairing codes expire after 10 min
+const DEFAULT_MAX_ATTEMPTS = 5               // failed guesses before the code burns
 
 export interface PairingManagerOptions {
   /** Telegram user IDs already trusted (loaded from settings on boot). */
@@ -11,6 +12,8 @@ export interface PairingManagerOptions {
   clock?: () => number
   /** How long a freshly generated pairing code stays valid. */
   codeTtlMs?: number
+  /** Failed pair attempts allowed before the pending code is invalidated. */
+  maxAttempts?: number
 }
 
 /**
@@ -26,15 +29,18 @@ export class PairingManager {
   private allowlist: Set<number>
   private pendingCode: string | null = null
   private codeExpiresAt: number | null = null
+  private failedAttempts = 0
   private readonly onChange?: (ids: number[]) => void
   private readonly clock: () => number
   private readonly codeTtlMs: number
+  private readonly maxAttempts: number
 
   constructor(opts: PairingManagerOptions = {}) {
     this.allowlist = new Set(opts.initialAllowlist ?? [])
     this.onChange = opts.onAllowlistChange
     this.clock = opts.clock ?? Date.now
     this.codeTtlMs = opts.codeTtlMs ?? DEFAULT_CODE_TTL_MS
+    this.maxAttempts = opts.maxAttempts ?? DEFAULT_MAX_ATTEMPTS
   }
 
   /** Generate a fresh 6-digit pairing code, replacing any previous one. */
@@ -42,6 +48,7 @@ export class PairingManager {
     const n = randomInt(0, 1_000_000)
     this.pendingCode = n.toString().padStart(6, '0')
     this.codeExpiresAt = this.clock() + this.codeTtlMs
+    this.failedAttempts = 0
     return this.pendingCode
   }
 
@@ -67,8 +74,16 @@ export class PairingManager {
     // Constant-time compare so the bot can't be used as a timing oracle.
     const a = Buffer.from(code)
     const b = Buffer.from(active)
-    if (a.length !== b.length) return false
-    if (!timingSafeEqual(a, b)) return false
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      // Anti-brute-force: a 6-digit code can't survive open-ended guessing,
+      // so burn it after maxAttempts misses. The owner just generates a new one.
+      this.failedAttempts++
+      if (this.failedAttempts >= this.maxAttempts) {
+        this.pendingCode = null
+        this.codeExpiresAt = null
+      }
+      return false
+    }
     // Consume the code so it can't be replayed, then trust the user.
     this.pendingCode = null
     this.codeExpiresAt = null

--- a/src/main/telegram/proposal-format.test.ts
+++ b/src/main/telegram/proposal-format.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import {
+  proposalCallback, parseProposalCallback,
+  formatProposalMessage, formatProposalDetails, formatProposalResolved
+} from './proposal-format'
+import type { ProposalView } from './bridge'
+
+const p: ProposalView = {
+  id: 'abc-123',
+  proposedBy: 'Cara',
+  summary: 'A research pod',
+  kind: 'team',
+  status: 'pending',
+  agents: [
+    { name: 'Ada', role: 'researcher', cli: 'claude', model: 'opus', notes: 'digs sources' },
+    { name: 'Rex', role: 'reviewer', cli: 'codex' }
+  ]
+}
+
+describe('proposal callback round-trip', () => {
+  it('encodes and parses each action', () => {
+    for (const action of ['approve', 'reject', 'info'] as const) {
+      const data = proposalCallback(action, 'abc-123')
+      expect(parseProposalCallback(data)).toEqual({ action, id: 'abc-123' })
+    }
+  })
+  it('preserves ids containing colons/dashes', () => {
+    expect(parseProposalCallback('prop:approve:a-b:c')).toEqual({ action: 'approve', id: 'a-b:c' })
+  })
+  it('rejects foreign or malformed payloads', () => {
+    expect(parseProposalCallback('other:approve:x')).toBeNull()
+    expect(parseProposalCallback('prop:delete:x')).toBeNull()
+    expect(parseProposalCallback('prop:approve:')).toBeNull()
+  })
+})
+
+describe('proposal formatting', () => {
+  it('lists agents in the card', () => {
+    const msg = formatProposalMessage(p)
+    expect(msg).toContain('Cara is proposing a team')
+    expect(msg).toContain('A research pod')
+    expect(msg).toContain('Ada — researcher (claude · opus)')
+    expect(msg).toContain('Rex — reviewer (codex)')
+  })
+  it('includes per-agent notes in details', () => {
+    const d = formatProposalDetails(p)
+    expect(d).toContain('digs sources')
+  })
+  it('marks the resolved state with an icon', () => {
+    expect(formatProposalResolved({ ...p, status: 'approved' })).toContain('✅ Approved')
+    expect(formatProposalResolved({ ...p, status: 'rejected' })).toContain('❌ Rejected')
+  })
+})

--- a/src/main/telegram/proposal-format.ts
+++ b/src/main/telegram/proposal-format.ts
@@ -1,0 +1,55 @@
+import type { ProposalView } from './bridge'
+
+/**
+ * Pure rendering + parsing for Telegram team-proposal cards. No grammY, no hub —
+ * just the message text and the callback-data round-trip, so the button wiring
+ * is unit-testable.
+ */
+
+export type ProposalAction = 'approve' | 'reject' | 'info'
+
+/** Encode a button's callback payload: prop:<action>:<proposalId>. */
+export function proposalCallback(action: ProposalAction, id: string): string {
+  return `prop:${action}:${id}`
+}
+
+/** Parse a callback payload back into (action, id), or null if it isn't ours. */
+export function parseProposalCallback(data: string): { action: ProposalAction; id: string } | null {
+  const m = /^prop:(approve|reject|info):(.+)$/.exec(data)
+  return m ? { action: m[1] as ProposalAction, id: m[2] } : null
+}
+
+/** The card shown when a proposal first arrives (buttons attached separately). */
+export function formatProposalMessage(p: ProposalView): string {
+  const noun = p.kind === 'schedule' ? 'schedule' : 'team'
+  const lines = [
+    `🧩 ${p.proposedBy} is proposing a ${noun}:`,
+    p.summary,
+  ]
+  if (p.agents.length) {
+    lines.push('', 'Agents:')
+    for (const a of p.agents) {
+      const model = a.model ? ` · ${a.model}` : ''
+      lines.push(`• ${a.name} — ${a.role} (${a.cli}${model})`)
+    }
+  }
+  lines.push('', 'Approve to spawn, or reject.')
+  return lines.join('\n')
+}
+
+/** The per-agent detail dump behind the 📋 Details button. */
+export function formatProposalDetails(p: ProposalView): string {
+  if (!p.agents.length) return 'No agent details available.'
+  return p.agents.map(a => {
+    const model = a.model ? ` · ${a.model}` : ''
+    const notes = a.notes?.trim() ? `\n   ${a.notes.trim()}` : ''
+    return `• ${a.name} — ${a.role} (${a.cli}${model})${notes}`
+  }).join('\n\n')
+}
+
+/** What the card becomes once the proposal is settled (buttons removed). */
+export function formatProposalResolved(p: ProposalView): string {
+  const icon = p.status === 'approved' ? '✅' : p.status === 'rejected' ? '❌' : '⚪'
+  const verb = p.status === 'approved' ? 'Approved' : p.status === 'rejected' ? 'Rejected' : p.status
+  return `${icon} ${verb}: ${p.summary}`
+}

--- a/src/main/telegram/telegram-server.test.ts
+++ b/src/main/telegram/telegram-server.test.ts
@@ -6,6 +6,7 @@ import type { OrchestratorBridge } from './bridge'
 const fakeBridge: OrchestratorBridge = {
   listTargets: () => [],
   sendTo: () => ({ ok: true }),
+  sendFile: () => ({ ok: true }),
   getOutput: () => [],
   postTask: () => ({ ok: true })
 }

--- a/src/main/telegram/telegram-server.test.ts
+++ b/src/main/telegram/telegram-server.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { TelegramServer } from './telegram-server'
 import { PairingManager } from './pairing-manager'
 import type { OrchestratorBridge } from './bridge'
@@ -19,5 +19,20 @@ describe('TelegramServer', () => {
   it('relayFromAgent is a safe no-op before the bot starts', () => {
     const s = new TelegramServer({ pairing: new PairingManager(), bridge: fakeBridge })
     expect(() => s.relayFromAgent('cara', 'hello from the swarm')).not.toThrow()
+  })
+
+  it('revokeUser cuts both command access and the relay subscription', () => {
+    const pairing = new PairingManager({ initialAllowlist: [111] })
+    const onChatsChange = vi.fn()
+    const s = new TelegramServer({
+      pairing,
+      bridge: fakeBridge,
+      initialChats: [111],   // private chat ID === user ID
+      onChatsChange
+    })
+    expect(s.revokeUser(111)).toBe(true)
+    expect(pairing.isAllowed(111)).toBe(false)
+    expect(onChatsChange).toHaveBeenLastCalledWith([])  // subscription persisted away
+    expect(s.revokeUser(111)).toBe(false)               // already gone
   })
 })

--- a/src/main/telegram/telegram-server.test.ts
+++ b/src/main/telegram/telegram-server.test.ts
@@ -7,6 +7,9 @@ const fakeBridge: OrchestratorBridge = {
   listTargets: () => [],
   sendTo: () => ({ ok: true }),
   sendFile: () => ({ ok: true }),
+  approveProposal: async () => ({ ok: true }),
+  rejectProposal: async () => ({ ok: true }),
+  getProposal: () => null,
   getOutput: () => [],
   postTask: () => ({ ok: true })
 }

--- a/src/main/telegram/telegram-server.test.ts
+++ b/src/main/telegram/telegram-server.test.ts
@@ -7,6 +7,7 @@ const fakeBridge: OrchestratorBridge = {
   listTargets: () => [],
   sendTo: () => ({ ok: true }),
   sendFile: () => ({ ok: true }),
+  sendVoice: async () => ({ ok: true }),
   approveProposal: async () => ({ ok: true }),
   rejectProposal: async () => ({ ok: true }),
   getProposal: () => null,

--- a/src/main/telegram/telegram-server.test.ts
+++ b/src/main/telegram/telegram-server.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { TelegramServer } from './telegram-server'
+import { PairingManager } from './pairing-manager'
+import type { OrchestratorBridge } from './bridge'
+
+const fakeBridge: OrchestratorBridge = {
+  listTargets: () => [],
+  sendTo: () => ({ ok: true }),
+  getOutput: () => [],
+  postTask: () => ({ ok: true })
+}
+
+describe('TelegramServer', () => {
+  it('constructs and reports not running before start', () => {
+    const s = new TelegramServer({ pairing: new PairingManager(), bridge: fakeBridge })
+    expect(s.isRunning()).toBe(false)
+  })
+
+  it('relayFromAgent is a safe no-op before the bot starts', () => {
+    const s = new TelegramServer({ pairing: new PairingManager(), bridge: fakeBridge })
+    expect(() => s.relayFromAgent('cara', 'hello from the swarm')).not.toThrow()
+  })
+})

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -1,6 +1,6 @@
-import { Bot } from 'grammy'
+import { Bot, type Context } from 'grammy'
 import type { PairingManager } from './pairing-manager'
-import type { OrchestratorBridge, TelegramTarget } from './bridge'
+import type { OrchestratorBridge, TelegramTarget, IncomingFile } from './bridge'
 import { ChatRouter } from './chat-router'
 
 /** Telegram caps a single message at 4096 chars; leave headroom for our prefix. */
@@ -178,7 +178,9 @@ export class TelegramServer {
         '/task <title> — post a task to the pinboard\n' +
         '/whoami — show your Telegram ID\n' +
         '/help — this list\n\n' +
-        'Plain text goes to this chat\'s active head (see /status).'
+        'Plain text goes to this chat\'s active head (see /status).\n' +
+        'Send a file or photo (with an optional caption) and it goes there too — ' +
+        'text files are read inline, images are saved for the agent to open.'
       )
     })
 
@@ -256,6 +258,51 @@ export class TelegramServer {
       const res = bridge.sendTo(target.name, ctx.message.text)
       if (!res.ok) await ctx.reply(`❌ ${res.detail ?? `Couldn't reach ${target.name}.`}`)
     })
+
+    // ── Attachments (documents + photos) → the chat's active head ───────────
+    // Download the bytes here (we have the bot token), then let the bridge save
+    // them into the project and route them to the agent.
+    bot.on(['message:document', 'message:photo'], async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const target = this.router.effectiveTarget(ctx.chat!.id, bridge.listTargets())
+      if (!target) { await ctx.reply('No agents are running. Start one in The Cog, then try again.'); return }
+
+      let file: IncomingFile
+      try {
+        file = await this.downloadAttachment(ctx)
+      } catch (err) {
+        this.log(`attachment download failed: ${err instanceof Error ? err.message : String(err)}`)
+        await ctx.reply('❌ Couldn\'t download that file from Telegram (it may be too large — the bot limit is 20 MB).')
+        return
+      }
+
+      const res = bridge.sendFile(target.name, file)
+      await ctx.reply(res.ok
+        ? `📎 Sent ${file.filename} to ${target.name}.`
+        : `❌ ${res.detail ?? 'Couldn\'t hand that file to the agent.'}`)
+    })
+  }
+
+  /**
+   * Pull the document/photo out of an update and download its bytes via the
+   * Telegram file API. Photos have no filename, so we synthesise one.
+   */
+  private async downloadAttachment(ctx: Context): Promise<IncomingFile> {
+    const doc = ctx.message?.document
+    const photo = ctx.message?.photo?.at(-1)  // last entry = highest resolution
+    const fileInfo = await ctx.getFile()      // resolves file_path for doc or largest photo
+    if (!fileInfo.file_path) throw new Error('no file_path (file too large or unavailable)')
+
+    const token = this.bot!.token
+    const res = await fetch(`https://api.telegram.org/file/bot${token}/${fileInfo.file_path}`)
+    if (!res.ok) throw new Error(`download HTTP ${res.status}`)
+    const bytes = new Uint8Array(await res.arrayBuffer())
+
+    const filename = doc?.file_name
+      ?? (photo ? `telegram-photo-${fileInfo.file_unique_id}.jpg` : `telegram-file-${fileInfo.file_unique_id}`)
+    const mimeType = doc?.mime_type ?? (photo ? 'image/jpeg' : undefined)
+    return { filename, bytes, mimeType, caption: ctx.message?.caption }
   }
 
   /**

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -1,8 +1,19 @@
 import { Bot } from 'grammy'
 import type { PairingManager } from './pairing-manager'
+import type { OrchestratorBridge, TelegramTarget } from './bridge'
+import { ChatRouter } from './chat-router'
+
+/** Telegram caps a single message at 4096 chars; leave headroom for our prefix. */
+const MAX_RELAY_CHARS = 3900
 
 export interface TelegramServerOptions {
   pairing: PairingManager
+  /**
+   * Bridge into the orchestration hub. Phase 1+ — when present, the trusted
+   * command router and the plain-text → orchestrator relay come alive. Omit it
+   * (Phase 0) and the bot is pairing-only.
+   */
+  bridge?: OrchestratorBridge
   /** Optional log sink — wire to the main-process logger. */
   onLog?: (message: string) => void
   /** Fired when connection/pairing state changes so the UI can refresh. */
@@ -10,27 +21,34 @@ export interface TelegramServerOptions {
 }
 
 /**
- * Phase 0 — scaffold + pairing only.
+ * Phase 1 — pairing gate + command router + orchestrator relay.
  *
  * Wraps a grammY bot in long-polling mode. No tunnel, no public ingress: the
  * bot reaches out to Telegram, so there's nothing to expose. (This is why the
  * Telegram bridge needs no cloudflared, unlike Remote View.)
  *
  * Auth: every update except the public pairing commands is dropped for users
- * not on the allowlist — the bot gives no sign it exists. The swarm relay
- * (Message Router tap) and command router (/status, /output, /task, …) attach
- * in Phase 1+ at the marked seam below, after the gate, so they're
- * trusted-only by default.
+ * not on the allowlist — the bot gives no sign it exists. Past the gate, a
+ * trusted user can drive the swarm: /status, /use, /msg, /output, /task, and
+ * plain text → the chat's active orchestrator. Agent→user messages are relayed
+ * back into every subscribed chat via relayFromAgent(), called from the main
+ * process's Message Router tap.
+ *
+ * Multi-orchestrator ("double-headed dragon") addressing lives in ChatRouter:
+ * each chat remembers which head it's talking to; /use switches it.
  */
 export class TelegramServer {
   private bot: Bot | null = null
   private running = false
   private readonly pairing: PairingManager
+  private readonly bridge?: OrchestratorBridge
+  private readonly router = new ChatRouter()
   private readonly log: (m: string) => void
   private readonly onStatusChange?: () => void
 
   constructor(opts: TelegramServerOptions) {
     this.pairing = opts.pairing
+    this.bridge = opts.bridge
     this.log = opts.onLog ?? (() => {})
     this.onStatusChange = opts.onStatusChange
   }
@@ -114,27 +132,137 @@ export class TelegramServer {
 
     // ── Allowlist gate ─────────────────────────────────────────────────────
     // Anything past this point requires a trusted user. Non-allowed updates
-    // are dropped silently (no next() call → chain ends).
+    // are dropped silently (no next() call → chain ends). A trusted chat is
+    // also registered here so it receives relayed orchestrator output.
     bot.use(async (ctx, next) => {
-      if (this.pairing.isAllowed(ctx.from?.id)) await next()
+      if (!this.pairing.isAllowed(ctx.from?.id)) return
+      if (ctx.chat) this.router.subscribe(ctx.chat.id)
+      await next()
     })
 
     // ── Trusted commands ───────────────────────────────────────────────────
     bot.command('help', async (ctx) => {
       await ctx.reply(
-        'The Cog — Telegram (Phase 0)\n' +
-        '/start — link status\n' +
+        'The Cog — Telegram (Phase 1)\n' +
+        '/status — list orchestrators & agents\n' +
+        '/use <name> — talk to a specific head (e.g. /use cara)\n' +
+        '/msg <name> <text> — one-off message to one agent\n' +
+        '/output [name] [n] — last n lines of an agent\'s terminal\n' +
+        '/task <title> — post a task to the pinboard\n' +
         '/whoami — show your Telegram ID\n' +
         '/help — this list\n\n' +
-        'Coming next: /status, /output, /task, and plain text → orchestrator.'
+        'Plain text goes to this chat\'s active head (see /status).'
       )
     })
 
-    // ───────────────────────────────────────────────────────────────────────
-    // PHASE 1+ SEAM
-    // Relay forwarder (Message Router tap → chat) and the command router
-    // (/status, /output, /msg, /task, schedules, plain text → orchestrator)
-    // attach here. They sit after the gate, so trusted-only by default.
-    // ───────────────────────────────────────────────────────────────────────
+    bot.command('status', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const targets = bridge.listTargets()
+      if (targets.length === 0) { await ctx.reply('No agents are running right now.'); return }
+      const active = this.router.effectiveTarget(ctx.chat!.id, targets)
+      await ctx.reply(this.formatStatus(targets, active))
+    })
+
+    bot.command('use', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const name = (ctx.match ?? '').trim()
+      if (!name) { await ctx.reply('Usage: /use <name> — pick an agent from /status.'); return }
+      const target = this.router.resolveTarget(name, bridge.listTargets())
+      if (!target) { await ctx.reply(`No agent matches "${name}". Try /status.`); return }
+      this.router.setActive(ctx.chat!.id, target.name)
+      await ctx.reply(`👉 Now talking to ${target.name} (${target.role}). Plain text routes here.`)
+    })
+
+    bot.command('msg', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const raw = (ctx.match ?? '').trim()
+      const sep = raw.search(/\s/)
+      if (sep === -1) { await ctx.reply('Usage: /msg <name> <text>'); return }
+      const name = raw.slice(0, sep)
+      const text = raw.slice(sep + 1).trim()
+      if (!text) { await ctx.reply('Usage: /msg <name> <text>'); return }
+      const target = this.router.resolveTarget(name, bridge.listTargets())
+      if (!target) { await ctx.reply(`No agent matches "${name}". Try /status.`); return }
+      const res = bridge.sendTo(target.name, text)
+      await ctx.reply(res.ok ? `📨 Sent to ${target.name}.` : `❌ ${res.detail ?? 'Send failed.'}`)
+    })
+
+    bot.command('output', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const parts = (ctx.match ?? '').trim().split(/\s+/).filter(Boolean)
+      // Trailing number is the line count; the rest (if any) is the agent name.
+      let lines = 20
+      if (parts.length && /^\d+$/.test(parts[parts.length - 1])) {
+        lines = Math.min(100, Math.max(1, parseInt(parts.pop()!, 10)))
+      }
+      const targets = bridge.listTargets()
+      const target = parts.length
+        ? this.router.resolveTarget(parts.join(' '), targets)
+        : this.router.effectiveTarget(ctx.chat!.id, targets)
+      if (!target) { await ctx.reply('No matching agent. Try /status.'); return }
+      const out = bridge.getOutput(target.name, lines)
+      if (out.length === 0) { await ctx.reply(`No recent output from ${target.name}.`); return }
+      await ctx.reply(this.clip(`🖥 ${target.name} (last ${out.length}):\n\n${out.join('\n')}`))
+    })
+
+    bot.command('task', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const title = (ctx.match ?? '').trim()
+      if (!title) { await ctx.reply('Usage: /task <title>'); return }
+      const res = bridge.postTask(title)
+      await ctx.reply(res.ok ? `✅ Task posted${res.id ? ` (${res.id})` : ''}.` : `❌ ${res.detail ?? 'Failed.'}`)
+    })
+
+    // ── Plain text → the chat's active head ────────────────────────────────
+    bot.on('message:text', async (ctx) => {
+      if (ctx.message.text.startsWith('/')) return  // unmatched command — ignore
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const targets = bridge.listTargets()
+      const target = this.router.effectiveTarget(ctx.chat!.id, targets)
+      if (!target) { await ctx.reply('No agents are running. Start one in The Cog, then try again.'); return }
+      const res = bridge.sendTo(target.name, ctx.message.text)
+      if (!res.ok) await ctx.reply(`❌ ${res.detail ?? `Couldn't reach ${target.name}.`}`)
+    })
+  }
+
+  /**
+   * Push an agent→user message into every subscribed chat. Called from the main
+   * process's Message Router tap (onMessageQueued, to === 'user'). Tagged with
+   * the sender so you can tell the dragon's heads apart.
+   */
+  relayFromAgent(fromName: string, message: string): void {
+    if (!this.bot || !this.running) return
+    const chats = this.router.subscribedChats()
+    if (chats.length === 0) return
+    const text = this.clip(`💬 ${fromName}:\n${message}`)
+    for (const chatId of chats) {
+      this.bot.api.sendMessage(chatId, text).catch((err) => {
+        this.log(`relay to ${chatId} failed: ${err instanceof Error ? err.message : String(err)}`)
+      })
+    }
+  }
+
+  private formatStatus(targets: TelegramTarget[], active: TelegramTarget | null): string {
+    const dot = (s: string) => (s === 'disconnected' ? '⚪' : s === 'active' ? '🟢' : '🟡')
+    const lines = targets.map((t) => {
+      const here = active && t.name === active.name ? '👉' : dot(t.status)
+      return `${here} ${t.name} · ${t.role} · ${t.status}`
+    })
+    const footer = active
+      ? `\nPlain text → ${active.name}. Switch with /use <name>.`
+      : '\nNo active head — /use <name> to pick one.'
+    return `The Cog — agents\n${lines.join('\n')}\n${footer}`
+  }
+
+  /** Trim to Telegram's message ceiling, keeping the tail (newest output). */
+  private clip(text: string): string {
+    if (text.length <= MAX_RELAY_CHARS) return text
+    return '…' + text.slice(text.length - MAX_RELAY_CHARS)
   }
 }

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -18,6 +18,19 @@ export interface TelegramServerOptions {
   onLog?: (message: string) => void
   /** Fired when connection/pairing state changes so the UI can refresh. */
   onStatusChange?: () => void
+  /** Relay-subscribed chat IDs from the last run, so restarts don't drop the relay. */
+  initialChats?: number[]
+  /** Fired when the subscribed-chat set changes so the caller can persist it. */
+  onChatsChange?: (chatIds: number[]) => void
+}
+
+/**
+ * Cheap token check without starting a poller: init() calls getMe and throws
+ * on a bad token or network failure. Lets callers validate a new token BEFORE
+ * persisting it over a known-good one.
+ */
+export async function validateBotToken(token: string): Promise<void> {
+  await new Bot(token).init()
 }
 
 /**
@@ -42,13 +55,17 @@ export class TelegramServer {
   private running = false
   private readonly pairing: PairingManager
   private readonly bridge?: OrchestratorBridge
-  private readonly router = new ChatRouter()
+  private readonly router: ChatRouter
   private readonly log: (m: string) => void
   private readonly onStatusChange?: () => void
 
   constructor(opts: TelegramServerOptions) {
     this.pairing = opts.pairing
     this.bridge = opts.bridge
+    this.router = new ChatRouter({
+      initialSubscribed: opts.initialChats,
+      onSubscribedChange: opts.onChatsChange
+    })
     this.log = opts.onLog ?? (() => {})
     this.onStatusChange = opts.onStatusChange
   }
@@ -76,7 +93,13 @@ export class TelegramServer {
     })
 
     // Throws on an invalid token / network failure — let the caller handle it.
-    await bot.init()
+    // Clear this.bot on failure so a later start() isn't wedged by the early return.
+    try {
+      await bot.init()
+    } catch (err) {
+      this.bot = null
+      throw err
+    }
     void bot.start({
       onStart: () => {
         this.running = true
@@ -102,7 +125,7 @@ export class TelegramServer {
     // ── Public commands (work before pairing) ──────────────────────────────
     bot.command('start', async (ctx) => {
       if (this.pairing.isAllowed(ctx.from?.id)) {
-        await ctx.reply('✅ You\'re linked to The Cog. Phase 0 is live — orchestration commands land in the next update. Try /help.')
+        await ctx.reply('✅ You\'re linked to The Cog. Try /help to drive the swarm.')
       } else {
         await ctx.reply('👋 To link this chat, open The Cog → Settings → Telegram and send the 6-digit code here as:\n\n/pair 123456')
       }
@@ -131,12 +154,16 @@ export class TelegramServer {
     })
 
     // ── Allowlist gate ─────────────────────────────────────────────────────
-    // Anything past this point requires a trusted user. Non-allowed updates
-    // are dropped silently (no next() call → chain ends). A trusted chat is
-    // also registered here so it receives relayed orchestrator output.
+    // Anything past this point requires a trusted user in a PRIVATE chat.
+    // Non-allowed updates are dropped silently (no next() call → chain ends).
+    // Groups are refused outright: pairing is per-user, but a subscription is
+    // per-chat — relaying agent output into a group would hand it to every
+    // member, paired or not. The trusted DM is registered here so it receives
+    // relayed orchestrator output.
     bot.use(async (ctx, next) => {
       if (!this.pairing.isAllowed(ctx.from?.id)) return
-      if (ctx.chat) this.router.subscribe(ctx.chat.id)
+      if (ctx.chat?.type !== 'private') return
+      this.router.subscribe(ctx.chat.id)
       await next()
     })
 
@@ -238,7 +265,10 @@ export class TelegramServer {
    */
   relayFromAgent(fromName: string, message: string): void {
     if (!this.bot || !this.running) return
-    const chats = this.router.subscribedChats()
+    // Recheck the allowlist at send time: only private chats subscribe, and a
+    // private chat's ID equals its user's ID, so a revoked user is filtered
+    // out here even if their chat somehow lingers in the router.
+    const chats = this.router.subscribedChats().filter((id) => this.pairing.isAllowed(id))
     if (chats.length === 0) return
     const text = this.clip(`💬 ${fromName}:\n${message}`)
     for (const chatId of chats) {
@@ -246,6 +276,17 @@ export class TelegramServer {
         this.log(`relay to ${chatId} failed: ${err instanceof Error ? err.message : String(err)}`)
       })
     }
+  }
+
+  /**
+   * Fully revoke a Telegram user: drop them from the allowlist AND cut their
+   * relay subscription (private chat ID === user ID). Both changes persist via
+   * the managers' change callbacks. Returns true if they were paired.
+   */
+  revokeUser(userId: number): boolean {
+    const had = this.pairing.revoke(userId)
+    this.router.forget(userId)
+    return had
   }
 
   private formatStatus(targets: TelegramTarget[], active: TelegramTarget | null): string {

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -157,6 +157,10 @@ export class TelegramServer {
       const userId = ctx.from?.id
       if (typeof userId !== 'number') return
       if (this.pairing.tryPair(userId, code)) {
+        // Subscribe the chat now (not just in the gate on the next message) so a
+        // relay or proposal that lands right after pairing isn't dropped, and
+        // the subscription is persisted immediately. Private chats only.
+        if (ctx.chat?.type === 'private') this.router.subscribe(ctx.chat.id)
         this.onStatusChange?.()
         await ctx.reply('✅ Linked! This chat can now talk to your orchestrator. Try /help.')
         this.log(`user ${userId} paired`)
@@ -371,7 +375,7 @@ export class TelegramServer {
     const doc = ctx.message?.document
     const photo = ctx.message?.photo?.at(-1)  // last entry = highest resolution
     const bytes = await this.downloadCurrentFile(ctx)
-    const uniqueId = ctx.message?.photo?.at(-1)?.file_unique_id ?? doc?.file_unique_id ?? 'file'
+    const uniqueId = photo?.file_unique_id ?? doc?.file_unique_id ?? 'file'
     const filename = doc?.file_name
       ?? (photo ? `telegram-photo-${uniqueId}.jpg` : `telegram-file-${uniqueId}`)
     const mimeType = doc?.mime_type ?? (photo ? 'image/jpeg' : undefined)
@@ -417,7 +421,14 @@ export class TelegramServer {
         this.log(`proposal push to ${chatId} failed: ${err instanceof Error ? err.message : String(err)}`)
       }
     }
-    if (sent.length) this.proposalMsgs.set(p.id, sent)
+    if (!sent.length) return
+    this.proposalMsgs.set(p.id, sent)
+    // Race guard: the proposal may have been resolved (desktop/3DS/expiry) while
+    // this push was in flight — relayProposalResolved would have found no map
+    // entry yet and bailed. Re-check the authoritative status and settle the
+    // freshly-sent cards now so they never keep live buttons on a done proposal.
+    const current = this.bridge?.getProposal(p.id)
+    if (current && current.status !== 'pending') this.relayProposalResolved(current)
   }
 
   /** Edit a proposal's cards to their settled state and strip the buttons. */

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -1,0 +1,140 @@
+import { Bot } from 'grammy'
+import type { PairingManager } from './pairing-manager'
+
+export interface TelegramServerOptions {
+  pairing: PairingManager
+  /** Optional log sink — wire to the main-process logger. */
+  onLog?: (message: string) => void
+  /** Fired when connection/pairing state changes so the UI can refresh. */
+  onStatusChange?: () => void
+}
+
+/**
+ * Phase 0 — scaffold + pairing only.
+ *
+ * Wraps a grammY bot in long-polling mode. No tunnel, no public ingress: the
+ * bot reaches out to Telegram, so there's nothing to expose. (This is why the
+ * Telegram bridge needs no cloudflared, unlike Remote View.)
+ *
+ * Auth: every update except the public pairing commands is dropped for users
+ * not on the allowlist — the bot gives no sign it exists. The swarm relay
+ * (Message Router tap) and command router (/status, /output, /task, …) attach
+ * in Phase 1+ at the marked seam below, after the gate, so they're
+ * trusted-only by default.
+ */
+export class TelegramServer {
+  private bot: Bot | null = null
+  private running = false
+  private readonly pairing: PairingManager
+  private readonly log: (m: string) => void
+  private readonly onStatusChange?: () => void
+
+  constructor(opts: TelegramServerOptions) {
+    this.pairing = opts.pairing
+    this.log = opts.onLog ?? (() => {})
+    this.onStatusChange = opts.onStatusChange
+  }
+
+  isRunning(): boolean {
+    return this.running
+  }
+
+  /**
+   * Start long-polling with the given bot token. Awaits init() so a bad token
+   * surfaces as a thrown error the Settings UI can show, then kicks off polling
+   * in the background (grammY's start() only resolves when the bot stops, so we
+   * deliberately don't await it). Call stop() before starting a new token.
+   */
+  async start(token: string): Promise<void> {
+    if (this.bot) return
+    const bot = new Bot(token)
+    this.bot = bot
+
+    this.registerHandlers(bot)
+
+    bot.catch((err) => {
+      const inner = err.error
+      this.log(`bot error: ${inner instanceof Error ? inner.message : String(inner)}`)
+    })
+
+    // Throws on an invalid token / network failure — let the caller handle it.
+    await bot.init()
+    void bot.start({
+      onStart: () => {
+        this.running = true
+        this.onStatusChange?.()
+      }
+    })
+    this.log(`bot @${bot.botInfo.username} started (long-poll)`)
+  }
+
+  async stop(): Promise<void> {
+    if (!this.bot) return
+    try {
+      await this.bot.stop()
+    } finally {
+      this.bot = null
+      this.running = false
+      this.onStatusChange?.()
+      this.log('bot stopped')
+    }
+  }
+
+  private registerHandlers(bot: Bot): void {
+    // ── Public commands (work before pairing) ──────────────────────────────
+    bot.command('start', async (ctx) => {
+      if (this.pairing.isAllowed(ctx.from?.id)) {
+        await ctx.reply('✅ You\'re linked to The Cog. Phase 0 is live — orchestration commands land in the next update. Try /help.')
+      } else {
+        await ctx.reply('👋 To link this chat, open The Cog → Settings → Telegram and send the 6-digit code here as:\n\n/pair 123456')
+      }
+    })
+
+    bot.command('pair', async (ctx) => {
+      const code = (ctx.match ?? '').trim()
+      if (!code) {
+        await ctx.reply('Usage: /pair <code> — the 6-digit code from The Cog → Settings → Telegram.')
+        return
+      }
+      const userId = ctx.from?.id
+      if (typeof userId !== 'number') return
+      if (this.pairing.tryPair(userId, code)) {
+        this.onStatusChange?.()
+        await ctx.reply('✅ Linked! This chat can now talk to your orchestrator. Try /help.')
+        this.log(`user ${userId} paired`)
+      } else {
+        await ctx.reply('❌ Invalid or expired code. Generate a fresh one in The Cog → Settings → Telegram.')
+      }
+    })
+
+    // Harmless helper — lets a user read their own ID for manual allowlisting.
+    bot.command('whoami', async (ctx) => {
+      await ctx.reply(`Your Telegram user ID: ${ctx.from?.id ?? 'unknown'}`)
+    })
+
+    // ── Allowlist gate ─────────────────────────────────────────────────────
+    // Anything past this point requires a trusted user. Non-allowed updates
+    // are dropped silently (no next() call → chain ends).
+    bot.use(async (ctx, next) => {
+      if (this.pairing.isAllowed(ctx.from?.id)) await next()
+    })
+
+    // ── Trusted commands ───────────────────────────────────────────────────
+    bot.command('help', async (ctx) => {
+      await ctx.reply(
+        'The Cog — Telegram (Phase 0)\n' +
+        '/start — link status\n' +
+        '/whoami — show your Telegram ID\n' +
+        '/help — this list\n\n' +
+        'Coming next: /status, /output, /task, and plain text → orchestrator.'
+      )
+    })
+
+    // ───────────────────────────────────────────────────────────────────────
+    // PHASE 1+ SEAM
+    // Relay forwarder (Message Router tap → chat) and the command router
+    // (/status, /output, /msg, /task, schedules, plain text → orchestrator)
+    // attach here. They sit after the gate, so trusted-only by default.
+    // ───────────────────────────────────────────────────────────────────────
+  }
+}

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -1,10 +1,24 @@
-import { Bot, type Context } from 'grammy'
+import { Bot, InlineKeyboard, type Context } from 'grammy'
 import type { PairingManager } from './pairing-manager'
-import type { OrchestratorBridge, TelegramTarget, IncomingFile } from './bridge'
+import type { OrchestratorBridge, TelegramTarget, IncomingFile, ProposalView } from './bridge'
 import { ChatRouter } from './chat-router'
+import {
+  proposalCallback, parseProposalCallback,
+  formatProposalMessage, formatProposalDetails, formatProposalResolved
+} from './proposal-format'
 
 /** Telegram caps a single message at 4096 chars; leave headroom for our prefix. */
 const MAX_RELAY_CHARS = 3900
+
+/** Urgency badge prepended to relayed inbox messages (normal → no badge). */
+function priorityPrefix(priority?: string): string {
+  switch (priority) {
+    case 'urgent': return '🔴 URGENT — '
+    case 'high': return '🟠 High — '
+    case 'low': return '⚪ '
+    default: return ''
+  }
+}
 
 export interface TelegramServerOptions {
   pairing: PairingManager
@@ -58,6 +72,9 @@ export class TelegramServer {
   private readonly router: ChatRouter
   private readonly log: (m: string) => void
   private readonly onStatusChange?: () => void
+  // proposalId → the chat messages carrying its buttons, so we can edit them to
+  // "settled" once it resolves (from Telegram, desktop, or 3DS).
+  private readonly proposalMsgs = new Map<string, Array<{ chatId: number; messageId: number }>>()
 
   constructor(opts: TelegramServerOptions) {
     this.pairing = opts.pairing
@@ -282,6 +299,32 @@ export class TelegramServer {
         ? `📎 Sent ${file.filename} to ${target.name}.`
         : `❌ ${res.detail ?? 'Couldn\'t hand that file to the agent.'}`)
     })
+
+    // ── Proposal buttons (Approve / Reject / Details) ──────────────────────
+    bot.on('callback_query:data', async (ctx) => {
+      const parsed = parseProposalCallback(ctx.callbackQuery.data)
+      if (!parsed) { await ctx.answerCallbackQuery(); return }
+      const bridge = this.bridge
+      if (!bridge) { await ctx.answerCallbackQuery('Orchestration isn\'t wired up.'); return }
+      const { action, id } = parsed
+
+      if (action === 'info') {
+        const p = bridge.getProposal(id)
+        await ctx.answerCallbackQuery()
+        await ctx.reply(p ? formatProposalDetails(p) : 'That proposal is no longer available.')
+        return
+      }
+
+      // approve / reject — resolving fires onProposalResolved in the main
+      // process, which calls relayProposalResolved() to edit the card. So we
+      // just trigger the action and acknowledge the tap here.
+      const result = action === 'approve'
+        ? await bridge.approveProposal(id)
+        : await bridge.rejectProposal(id)
+      await ctx.answerCallbackQuery(result.ok
+        ? (action === 'approve' ? '✅ Approved' : '❌ Rejected')
+        : (result.detail ?? 'Could not update the proposal.'))
+    })
   }
 
   /**
@@ -310,19 +353,61 @@ export class TelegramServer {
    * process's Message Router tap (onMessageQueued, to === 'user'). Tagged with
    * the sender so you can tell the dragon's heads apart.
    */
-  relayFromAgent(fromName: string, message: string): void {
+  relayFromAgent(fromName: string, message: string, priority?: string): void {
     if (!this.bot || !this.running) return
     // Recheck the allowlist at send time: only private chats subscribe, and a
     // private chat's ID equals its user's ID, so a revoked user is filtered
     // out here even if their chat somehow lingers in the router.
-    const chats = this.router.subscribedChats().filter((id) => this.pairing.isAllowed(id))
+    const chats = this.subscribedAllowedChats()
     if (chats.length === 0) return
-    const text = this.clip(`💬 ${fromName}:\n${message}`)
+    const text = this.clip(`${priorityPrefix(priority)}💬 ${fromName}:\n${message}`)
     for (const chatId of chats) {
       this.bot.api.sendMessage(chatId, text).catch((err) => {
         this.log(`relay to ${chatId} failed: ${err instanceof Error ? err.message : String(err)}`)
       })
     }
+  }
+
+  /** Push a pending proposal to every linked chat with Approve/Reject/Details buttons. */
+  async relayProposal(p: ProposalView): Promise<void> {
+    if (!this.bot || !this.running) return
+    const chats = this.subscribedAllowedChats()
+    if (chats.length === 0) return
+    const keyboard = new InlineKeyboard()
+      .text('✅ Approve', proposalCallback('approve', p.id))
+      .text('❌ Reject', proposalCallback('reject', p.id)).row()
+      .text('📋 Details', proposalCallback('info', p.id))
+    const text = this.clip(formatProposalMessage(p))
+    const sent: Array<{ chatId: number; messageId: number }> = []
+    for (const chatId of chats) {
+      try {
+        const msg = await this.bot.api.sendMessage(chatId, text, { reply_markup: keyboard })
+        sent.push({ chatId, messageId: msg.message_id })
+      } catch (err) {
+        this.log(`proposal push to ${chatId} failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    }
+    if (sent.length) this.proposalMsgs.set(p.id, sent)
+  }
+
+  /** Edit a proposal's cards to their settled state and strip the buttons. */
+  relayProposalResolved(p: ProposalView): void {
+    if (!this.bot) return
+    const msgs = this.proposalMsgs.get(p.id)
+    if (!msgs) return
+    this.proposalMsgs.delete(p.id)
+    const text = formatProposalResolved(p)
+    for (const { chatId, messageId } of msgs) {
+      // Drop the keyboard by omitting reply_markup on the edit.
+      this.bot.api.editMessageText(chatId, messageId, text).catch((err) => {
+        this.log(`proposal edit ${chatId}/${messageId} failed: ${err instanceof Error ? err.message : String(err)}`)
+      })
+    }
+  }
+
+  /** Subscribed chats that still map to a trusted user (private chat ID === user ID). */
+  private subscribedAllowedChats(): number[] {
+    return this.router.subscribedChats().filter((id) => this.pairing.isAllowed(id))
   }
 
   /**

--- a/src/main/telegram/telegram-server.ts
+++ b/src/main/telegram/telegram-server.ts
@@ -1,6 +1,6 @@
 import { Bot, InlineKeyboard, type Context } from 'grammy'
 import type { PairingManager } from './pairing-manager'
-import type { OrchestratorBridge, TelegramTarget, IncomingFile, ProposalView } from './bridge'
+import type { OrchestratorBridge, TelegramTarget, IncomingFile, IncomingVoice, ProposalView } from './bridge'
 import { ChatRouter } from './chat-router'
 import {
   proposalCallback, parseProposalCallback,
@@ -197,7 +197,8 @@ export class TelegramServer {
         '/help — this list\n\n' +
         'Plain text goes to this chat\'s active head (see /status).\n' +
         'Send a file or photo (with an optional caption) and it goes there too — ' +
-        'text files are read inline, images are saved for the agent to open.'
+        'text files are read inline, images are saved for the agent to open.\n' +
+        'Send a voice note and it\'s transcribed and routed to the active head.'
       )
     })
 
@@ -300,6 +301,32 @@ export class TelegramServer {
         : `❌ ${res.detail ?? 'Couldn\'t hand that file to the agent.'}`)
     })
 
+    // ── Voice notes → transcribe → the chat's active head ──────────────────
+    bot.on('message:voice', async (ctx) => {
+      const bridge = this.bridge
+      if (!bridge) { await ctx.reply('Orchestration isn\'t wired up yet.'); return }
+      const target = this.router.effectiveTarget(ctx.chat!.id, bridge.listTargets())
+      if (!target) { await ctx.reply('No agents are running. Start one in The Cog, then try again.'); return }
+
+      let bytes: Uint8Array
+      try {
+        bytes = await this.downloadCurrentFile(ctx)
+      } catch (err) {
+        this.log(`voice download failed: ${err instanceof Error ? err.message : String(err)}`)
+        await ctx.reply('❌ Couldn\'t download that voice note.')
+        return
+      }
+
+      // Transcription can take a moment — show the "typing…" indicator.
+      await ctx.replyWithChatAction('typing').catch(() => {})
+      const voice: IncomingVoice = { bytes, mimeType: ctx.message.voice.mime_type, caption: ctx.message.caption }
+      const res = await bridge.sendVoice(target.name, voice)
+      if (!res.ok) { await ctx.reply(`❌ ${res.detail ?? 'Couldn\'t process that voice note.'}`); return }
+      await ctx.reply(res.transcript
+        ? `🎙️ "${res.transcript}"\n→ sent to ${target.name}.`
+        : `🎙️ Voice saved for ${target.name}${res.detail ? ` — ${res.detail}` : ''}.`)
+    })
+
     // ── Proposal buttons (Approve / Reject / Details) ──────────────────────
     bot.on('callback_query:data', async (ctx) => {
       const parsed = parseProposalCallback(ctx.callbackQuery.data)
@@ -327,23 +354,26 @@ export class TelegramServer {
     })
   }
 
+  /** Download the file referenced by the current update via the Telegram file API. */
+  private async downloadCurrentFile(ctx: Context): Promise<Uint8Array> {
+    const fileInfo = await ctx.getFile()  // resolves file_path for the update's file
+    if (!fileInfo.file_path) throw new Error('no file_path (file too large or unavailable)')
+    const res = await fetch(`https://api.telegram.org/file/bot${this.bot!.token}/${fileInfo.file_path}`)
+    if (!res.ok) throw new Error(`download HTTP ${res.status}`)
+    return new Uint8Array(await res.arrayBuffer())
+  }
+
   /**
-   * Pull the document/photo out of an update and download its bytes via the
-   * Telegram file API. Photos have no filename, so we synthesise one.
+   * Pull the document/photo out of an update and download its bytes. Photos have
+   * no filename, so we synthesise one from the file's unique id.
    */
   private async downloadAttachment(ctx: Context): Promise<IncomingFile> {
     const doc = ctx.message?.document
     const photo = ctx.message?.photo?.at(-1)  // last entry = highest resolution
-    const fileInfo = await ctx.getFile()      // resolves file_path for doc or largest photo
-    if (!fileInfo.file_path) throw new Error('no file_path (file too large or unavailable)')
-
-    const token = this.bot!.token
-    const res = await fetch(`https://api.telegram.org/file/bot${token}/${fileInfo.file_path}`)
-    if (!res.ok) throw new Error(`download HTTP ${res.status}`)
-    const bytes = new Uint8Array(await res.arrayBuffer())
-
+    const bytes = await this.downloadCurrentFile(ctx)
+    const uniqueId = ctx.message?.photo?.at(-1)?.file_unique_id ?? doc?.file_unique_id ?? 'file'
     const filename = doc?.file_name
-      ?? (photo ? `telegram-photo-${fileInfo.file_unique_id}.jpg` : `telegram-file-${fileInfo.file_unique_id}`)
+      ?? (photo ? `telegram-photo-${uniqueId}.jpg` : `telegram-file-${uniqueId}`)
     const mimeType = doc?.mime_type ?? (photo ? 'image/jpeg' : undefined)
     return { filename, bytes, mimeType, caption: ctx.message?.caption }
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -108,10 +108,16 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke(IPC.PROPOSALS_APPROVE, { proposalId, agents, tabId }),
   proposalsReject: (proposalId: string, feedback?: string) =>
     ipcRenderer.invoke(IPC.PROPOSALS_REJECT, { proposalId, feedback }),
+  proposalsReopen: (id: string) => ipcRenderer.invoke(IPC.PROPOSALS_REOPEN, id),
   onProposalAdded: (callback: (proposal: unknown) => void) => {
     const handler = (_event: unknown, proposal: unknown) => callback(proposal)
     ipcRenderer.on(IPC.PROPOSAL_ADDED, handler)
     return () => ipcRenderer.removeListener(IPC.PROPOSAL_ADDED, handler)
+  },
+  onProposalResolved: (callback: (proposal: unknown) => void) => {
+    const handler = (_event: unknown, proposal: unknown) => callback(proposal)
+    ipcRenderer.on(IPC.PROPOSAL_RESOLVED, handler)
+    return () => ipcRenderer.removeListener(IPC.PROPOSAL_RESOLVED, handler)
   },
   // Groups
   getGroups: () => ipcRenderer.invoke(IPC.GROUP_GET_ALL),

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -219,6 +219,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(IPC.REMOTE_SETUP_PROGRESS, handler)
     return () => ipcRenderer.removeListener(IPC.REMOTE_SETUP_PROGRESS, handler)
   },
+  // Telegram orchestration
+  enableTelegram: () => ipcRenderer.invoke(IPC.TELEGRAM_ENABLE),
+  disableTelegram: () => ipcRenderer.invoke(IPC.TELEGRAM_DISABLE),
+  setTelegramToken: (token: string) => ipcRenderer.invoke(IPC.TELEGRAM_SET_TOKEN, token),
+  getTelegramPairingCode: () => ipcRenderer.invoke(IPC.TELEGRAM_GET_PAIRING_CODE),
+  unpairTelegram: (userId: number) => ipcRenderer.invoke(IPC.TELEGRAM_UNPAIR, userId),
+  getTelegramStatus: () => ipcRenderer.invoke(IPC.TELEGRAM_GET_STATUS),
+  onTelegramStatusUpdate: (callback: (status: unknown) => void) => {
+    const handler = (_event: unknown, status: unknown) => callback(status)
+    ipcRenderer.on(IPC.TELEGRAM_STATUS_UPDATE, handler)
+    return () => ipcRenderer.removeListener(IPC.TELEGRAM_STATUS_UPDATE, handler)
+  },
   // Workshop passcode
   setWorkshopPasscode: (pin: string) => ipcRenderer.invoke(IPC.WORKSHOP_SET_PASSCODE, pin),
   getWorkshopPasscodeSet: () => ipcRenderer.invoke(IPC.WORKSHOP_GET_PASSCODE_SET),

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -274,7 +274,12 @@ export function App(): React.ReactElement {
       // open the next one after dismissing the current.
       setPendingProposal(prev => prev ?? proposal)
     })
-    return () => { mounted = false; off() }
+    // Auto-close the popup if the proposal it's showing gets resolved elsewhere
+    // (approved/rejected from the inbox re-open, 3DS, or Telegram).
+    const offResolved = window.electronAPI.onProposalResolved((resolved) => {
+      setPendingProposal(prev => (prev && prev.id === resolved.id ? null : prev))
+    })
+    return () => { mounted = false; off(); offResolved() }
     // We only want this to run once per project mount; pendingProposal in
     // deps would cause re-subscription churn.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/components/InboxPanel.tsx
+++ b/src/renderer/components/InboxPanel.tsx
@@ -122,6 +122,8 @@ export function InboxPanel(): React.ReactElement {
   const [threshold, setThreshold] = useState<NotificationThreshold>('high')
   const [replying, setReplying] = useState<string | null>(null)
   const [replyText, setReplyText] = useState('')
+  // Proposal IDs already settled — hide the Review button for these.
+  const [resolvedProposals, setResolvedProposals] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     let mounted = true
@@ -129,8 +131,24 @@ export function InboxPanel(): React.ReactElement {
     window.electronAPI.inboxGetNotifyThreshold().then(t => { if (mounted) setThreshold(t) })
     const offAdd = window.electronAPI.onInboxMessageAdded((msgs) => setMessages(msgs))
     const offUpd = window.electronAPI.onInboxMessageUpdated((msgs) => setMessages(msgs))
-    return () => { mounted = false; offAdd(); offUpd() }
+    const offResolved = window.electronAPI.onProposalResolved((p) => {
+      setResolvedProposals(prev => new Set(prev).add(p.id))
+    })
+    return () => { mounted = false; offAdd(); offUpd(); offResolved() }
   }, [])
+
+  // A message wraps a team proposal when it carries a `proposal:<id>` tag.
+  const proposalIdOf = (m: InboxMessage): string | null => {
+    const tag = m.tags.find(t => t.startsWith('proposal:'))
+    return tag ? tag.slice('proposal:'.length) : null
+  }
+  const handleReviewProposal = async (id: string) => {
+    const res = await window.electronAPI.proposalsReopen(id)
+    if (!res.ok) {
+      // Already approved/rejected/expired/gone — mark it settled so the button hides.
+      setResolvedProposals(prev => new Set(prev).add(id))
+    }
+  }
 
   const filtered = useMemo(() => {
     return messages.filter(m => {
@@ -225,6 +243,16 @@ export function InboxPanel(): React.ReactElement {
                 <span style={dateStyle}>{formatDate(m.createdAt)}</span>
               </div>
               <div style={{ color: '#ddd', fontSize: '13px', lineHeight: 1.45 }}>{m.message}</div>
+              {(() => {
+                const proposalId = proposalIdOf(m)
+                if (!proposalId || resolvedProposals.has(proposalId)) return null
+                return (
+                  <button
+                    onClick={() => handleReviewProposal(proposalId)}
+                    style={{ ...buttonStyle, marginTop: '8px', color: '#8cffa0', borderColor: '#2d663a', backgroundColor: '#16281c' }}
+                  >Open / Review team proposal ▸</button>
+                )
+              })()}
               <div style={{ display: 'flex', gap: '6px', marginTop: '8px' }}>
                 {isUnread && (
                   <button onClick={() => handleMarkRead(m.id)} style={buttonStyle}>Mark read</button>

--- a/src/renderer/components/InboxPanel.tsx
+++ b/src/renderer/components/InboxPanel.tsx
@@ -122,19 +122,30 @@ export function InboxPanel(): React.ReactElement {
   const [threshold, setThreshold] = useState<NotificationThreshold>('high')
   const [replying, setReplying] = useState<string | null>(null)
   const [replyText, setReplyText] = useState('')
-  // Proposal IDs already settled — hide the Review button for these.
+  // Proposal IDs still pending (seeded on mount) and ones settled since.
+  // The Review button shows only for a still-pending proposal.
+  const [pendingProposals, setPendingProposals] = useState<Set<string>>(new Set())
   const [resolvedProposals, setResolvedProposals] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     let mounted = true
     window.electronAPI.inboxList().then(msgs => { if (mounted) setMessages(msgs) })
     window.electronAPI.inboxGetNotifyThreshold().then(t => { if (mounted) setThreshold(t) })
+    // Seed pending proposals so historical, already-resolved proposal messages
+    // don't render a stale "Review" button after a restart/remount.
+    window.electronAPI.proposalsListPending().then(list => {
+      if (mounted) setPendingProposals(new Set(list.map(p => p.id)))
+    })
     const offAdd = window.electronAPI.onInboxMessageAdded((msgs) => setMessages(msgs))
     const offUpd = window.electronAPI.onInboxMessageUpdated((msgs) => setMessages(msgs))
+    // Track proposals that arrive while mounted so their Review button shows too.
+    const offProposal = window.electronAPI.onProposalAdded((p) => {
+      setPendingProposals(prev => new Set(prev).add(p.id))
+    })
     const offResolved = window.electronAPI.onProposalResolved((p) => {
       setResolvedProposals(prev => new Set(prev).add(p.id))
     })
-    return () => { mounted = false; offAdd(); offUpd(); offResolved() }
+    return () => { mounted = false; offAdd(); offUpd(); offProposal(); offResolved() }
   }, [])
 
   // A message wraps a team proposal when it carries a `proposal:<id>` tag.
@@ -245,7 +256,7 @@ export function InboxPanel(): React.ReactElement {
               <div style={{ color: '#ddd', fontSize: '13px', lineHeight: 1.45 }}>{m.message}</div>
               {(() => {
                 const proposalId = proposalIdOf(m)
-                if (!proposalId || resolvedProposals.has(proposalId)) return null
+                if (!proposalId || !pendingProposals.has(proposalId) || resolvedProposals.has(proposalId)) return null
                 return (
                   <button
                     onClick={() => handleReviewProposal(proposalId)}

--- a/src/renderer/components/SettingsDialog.tsx
+++ b/src/renderer/components/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { AutonomySettings } from './AutonomySettings'
 import QRCode from 'qrcode-svg'
-import type { AgentState, WorkspaceTheme, CommunityThemeListItem, CommunityTheme, AgentTheme } from '../../shared/types'
+import type { AgentState, WorkspaceTheme, CommunityThemeListItem, CommunityTheme, AgentTheme, TelegramStatus } from '../../shared/types'
 import { ROLE_THEME_DEFAULTS, getPresetById, THEME_PRESETS, WORKSPACE_THEMES, getWorkspaceThemeById } from '../themes'
 
 declare const electronAPI: {
@@ -1010,6 +1010,9 @@ export function SettingsDialog({ onClose, agents = [] }: SettingsDialogProps): R
           )}
         </div>
 
+        {/* Telegram Bot section */}
+        <TelegramSection />
+
         {/* Agent Autonomy section */}
         <AutonomySettings projectName={projectName} />
 
@@ -1021,6 +1024,224 @@ export function SettingsDialog({ onClose, agents = [] }: SettingsDialogProps): R
           borderRadius: '4px', color: '#aaa', cursor: 'pointer', fontSize: '13px', alignSelf: 'flex-end'
         }}>Done</button>
       </div>
+    </div>
+  )
+}
+
+function TelegramSection(): React.ReactElement {
+  const [status, setStatus] = React.useState<TelegramStatus | null>(null)
+  const [showTokenInput, setShowTokenInput] = React.useState(false)
+  const [tokenInput, setTokenInput] = React.useState('')
+  const [busy, setBusy] = React.useState(false)
+  const [error, setError] = React.useState<string | null>(null)
+  const [notice, setNotice] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    void window.electronAPI.getTelegramStatus().then(setStatus)
+    const off = window.electronAPI.onTelegramStatusUpdate(setStatus)
+    return () => off()
+  }, [])
+
+  const flash = (msg: string) => {
+    setNotice(msg)
+    setTimeout(() => setNotice(null), 2500)
+  }
+
+  // IPC rejections arrive as "Error invoking remote method 'x': Error: <real message>"
+  const ipcError = (err: unknown): string =>
+    (err instanceof Error ? err.message : String(err)).replace(/^Error invoking remote method '[^']+':\s*(Error:\s*)?/, '')
+
+  const saveToken = async () => {
+    const token = tokenInput.trim()
+    if (!token || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      // Validated against Telegram before it's persisted — a typo can't
+      // clobber a working token.
+      await window.electronAPI.setTelegramToken(token)
+      setTokenInput('')
+      setShowTokenInput(false)
+      flash('Token verified and saved')
+    } catch (err) {
+      setError(`Token rejected: ${ipcError(err)}`)
+    }
+    setBusy(false)
+  }
+
+  const toggleBot = async () => {
+    if (!status?.hasToken || busy) return
+    setBusy(true)
+    setError(null)
+    try {
+      if (status.enabled) await window.electronAPI.disableTelegram()
+      else await window.electronAPI.enableTelegram()
+    } catch (err) {
+      setError(ipcError(err))
+    }
+    setBusy(false)
+  }
+
+  const generateCode = async () => {
+    setError(null)
+    await window.electronAPI.getTelegramPairingCode()
+    // The status-update event delivers the new code; no local state needed.
+  }
+
+  const unpair = async (id: number) => {
+    if (!confirm(`Unpair Telegram account ${id}? It will lose access to your agents.`)) return
+    await window.electronAPI.unpairTelegram(id)
+  }
+
+  const rowStyle: React.CSSProperties = {
+    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+    padding: '8px', backgroundColor: '#252525', borderRadius: '4px', gap: '8px'
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', borderTop: '1px solid #333', paddingTop: '16px' }}>
+      <div style={{ fontSize: '12px', color: '#888', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+        Telegram Bot <span style={{ color: '#eab308', textTransform: 'none', fontWeight: 600 }}>(experimental)</span>
+      </div>
+      <div style={{ fontSize: '11px', color: '#666', lineHeight: '1.5' }}>
+        Drive your agents from your phone: /status, /use, /msg, /output, /task — and agent replies
+        land in your chat. Create a bot with @BotFather in Telegram, paste its token, then pair.
+        Works in direct messages only.
+      </div>
+
+      {/* Bot token */}
+      <div style={rowStyle}>
+        <div style={{ minWidth: 0 }}>
+          <div style={{ fontSize: '13px', color: '#e0e0e0' }}>Bot token</div>
+          <div style={{ fontSize: '11px', color: '#666' }}>
+            {status?.hasToken ? 'Saved (stored encrypted)' : 'Paste the token from @BotFather'}
+          </div>
+        </div>
+        {showTokenInput ? (
+          <div style={{ display: 'flex', gap: '6px', flexShrink: 0 }}>
+            <input
+              type="password"
+              autoFocus
+              placeholder="123456:ABC-DEF…"
+              value={tokenInput}
+              onChange={e => setTokenInput(e.target.value)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') saveToken()
+                if (e.key === 'Escape') { setShowTokenInput(false); setTokenInput('') }
+              }}
+              style={{
+                width: '150px', padding: '4px 8px', backgroundColor: '#333', color: '#e0e0e0',
+                border: '1px solid #555', borderRadius: '4px', fontSize: '12px'
+              }}
+            />
+            <button
+              onClick={saveToken}
+              disabled={!tokenInput.trim() || busy}
+              style={{
+                padding: '4px 10px', backgroundColor: '#3b82f6', color: '#fff',
+                border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px',
+                opacity: tokenInput.trim() && !busy ? 1 : 0.5
+              }}
+            >{busy ? '…' : 'Save'}</button>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowTokenInput(true)}
+            style={{
+              padding: '4px 10px', backgroundColor: '#333', color: '#e0e0e0',
+              border: '1px solid #555', borderRadius: '4px', cursor: 'pointer', fontSize: '12px', flexShrink: 0
+            }}
+          >{status?.hasToken ? 'Change' : 'Set token'}</button>
+        )}
+      </div>
+
+      {/* Enable toggle */}
+      <label style={{ ...rowStyle, cursor: status?.hasToken ? 'pointer' : 'not-allowed', opacity: status?.hasToken ? 1 : 0.5 }}>
+        <div>
+          <div style={{ fontSize: '13px', color: '#e0e0e0' }}>Enable Telegram bot</div>
+          <div style={{ fontSize: '11px', color: '#666' }}>
+            {status?.enabled ? 'Running — long-polling Telegram (no tunnel needed)' : 'Bot is off'}
+          </div>
+        </div>
+        <div
+          onClick={toggleBot}
+          style={{
+            width: 40, height: 22, borderRadius: 11,
+            backgroundColor: status?.enabled ? '#4caf50' : '#444',
+            position: 'relative', cursor: status?.hasToken ? 'pointer' : 'not-allowed',
+            transition: 'background-color 0.2s', flexShrink: 0, marginLeft: 12
+          }}
+        >
+          <div style={{
+            width: 18, height: 18, borderRadius: '50%',
+            backgroundColor: '#fff', position: 'absolute', top: 2,
+            left: status?.enabled ? 20 : 2,
+            transition: 'left 0.2s'
+          }} />
+        </div>
+      </label>
+
+      {/* Pairing — only meaningful while the bot is running */}
+      {status?.enabled && (
+        <>
+          <div style={rowStyle}>
+            <div>
+              <div style={{ fontSize: '13px', color: '#e0e0e0' }}>Pair a phone</div>
+              <div style={{ fontSize: '11px', color: '#666' }}>Code is single-use and expires in 10 minutes</div>
+            </div>
+            {status.activePairingCode ? (
+              <div style={{
+                fontSize: '18px', fontFamily: 'monospace', letterSpacing: '3px',
+                color: '#6ee7b7', padding: '2px 10px', backgroundColor: '#1a2e1a',
+                borderRadius: '4px', flexShrink: 0
+              }}>{status.activePairingCode}</div>
+            ) : (
+              <button
+                onClick={generateCode}
+                style={{
+                  padding: '4px 10px', backgroundColor: '#333', color: '#e0e0e0',
+                  border: '1px solid #555', borderRadius: '4px', cursor: 'pointer', fontSize: '12px', flexShrink: 0
+                }}
+              >Generate code</button>
+            )}
+          </div>
+          {status.activePairingCode && (
+            <div style={{ fontSize: '11px', color: '#888', padding: '0 4px' }}>
+              Message your bot in Telegram: <span style={{ fontFamily: 'monospace', color: '#e0e0e0' }}>/pair {status.activePairingCode}</span>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Paired accounts — shown even while the bot is off so unpair always works */}
+      {status && status.pairedIds.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <div style={{ fontSize: '11px', color: '#666' }}>Linked Telegram accounts</div>
+          {status.pairedIds.map(id => (
+            <div key={id} style={rowStyle}>
+              <div style={{ fontSize: '12px', color: '#e0e0e0', fontFamily: 'monospace' }}>{id}</div>
+              <button
+                onClick={() => unpair(id)}
+                style={{
+                  padding: '3px 10px', backgroundColor: '#3a2222', color: '#ef8888',
+                  border: '1px solid #5a3333', borderRadius: '4px', cursor: 'pointer', fontSize: '11px', flexShrink: 0
+                }}
+              >Unpair</button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div style={{ fontSize: '11px', color: '#ef4444', padding: '4px 8px', backgroundColor: '#2e1a1a', borderRadius: '4px' }}>
+          {error}
+        </div>
+      )}
+      {notice && (
+        <div style={{ fontSize: '11px', color: '#6ee7b7', padding: '4px 8px', backgroundColor: '#1a2e1a', borderRadius: '4px' }}>
+          {notice}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/SettingsDialog.tsx
+++ b/src/renderer/components/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react'
 import { AutonomySettings } from './AutonomySettings'
 import QRCode from 'qrcode-svg'
-import type { AgentState, WorkspaceTheme, CommunityThemeListItem, CommunityTheme, AgentTheme, TelegramStatus } from '../../shared/types'
+import type { AgentState, WorkspaceTheme, CommunityThemeListItem, CommunityTheme, AgentTheme, TelegramStatus, NotificationThreshold } from '../../shared/types'
 import { ROLE_THEME_DEFAULTS, getPresetById, THEME_PRESETS, WORKSPACE_THEMES, getWorkspaceThemeById } from '../themes'
 
 declare const electronAPI: {
@@ -1035,12 +1035,22 @@ function TelegramSection(): React.ReactElement {
   const [busy, setBusy] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
   const [notice, setNotice] = React.useState<string | null>(null)
+  const [threshold, setThreshold] = React.useState<NotificationThreshold>('low')
 
   React.useEffect(() => {
     void window.electronAPI.getTelegramStatus().then(setStatus)
+    void window.electronAPI.getSettings().then(s => {
+      const t = s.telegramNotifyThreshold
+      if (typeof t === 'string') setThreshold(t as NotificationThreshold)
+    })
     const off = window.electronAPI.onTelegramStatusUpdate(setStatus)
     return () => off()
   }, [])
+
+  const changeThreshold = async (t: NotificationThreshold) => {
+    setThreshold(t)
+    await window.electronAPI.setSetting('telegramNotifyThreshold', t)
+  }
 
   const flash = (msg: string) => {
     setNotice(msg)
@@ -1179,6 +1189,30 @@ function TelegramSection(): React.ReactElement {
             transition: 'left 0.2s'
           }} />
         </div>
+      </label>
+
+      {/* Which inbox priorities get pushed to Telegram */}
+      <label style={{ ...rowStyle }}>
+        <div>
+          <div style={{ fontSize: '13px', color: '#e0e0e0' }}>Send to Telegram when</div>
+          <div style={{ fontSize: '11px', color: '#666' }}>
+            Mirror inbox messages at or above this urgency to your phone.
+          </div>
+        </div>
+        <select
+          value={threshold}
+          onChange={e => changeThreshold(e.target.value as NotificationThreshold)}
+          style={{
+            backgroundColor: '#1a1a1a', color: '#e0e0e0', border: '1px solid #3a3a3a',
+            borderRadius: 4, padding: '4px 8px', fontSize: 12, marginLeft: 12, flexShrink: 0
+          }}
+        >
+          <option value="low">Everything</option>
+          <option value="normal">Normal &amp; up</option>
+          <option value="high">High &amp; up</option>
+          <option value="urgent">Urgent only</option>
+          <option value="none">Nothing (off)</option>
+        </select>
       </label>
 
       {/* Pairing — only meaningful while the bot is running */}

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -40,7 +40,11 @@ declare global {
         totalRequested?: number
       }>
       proposalsReject: (proposalId: string, feedback?: string) => Promise<{ success: boolean; error?: string }>
+      proposalsReopen: (id: string) => Promise<{ ok: boolean; status: 'pending' | 'approved' | 'rejected' | 'expired' | 'missing' }>
+      getSettings: () => Promise<Record<string, unknown>>
+      setSetting: (key: string, value: unknown) => Promise<{ status: string }>
       onProposalAdded: (callback: (proposal: TeamProposal) => void) => () => void
+      onProposalResolved: (callback: (proposal: TeamProposal) => void) => () => void
       onPtyOutput: (callback: (agentId: string, data: string) => void) => () => void
       onPtyExit: (callback: (agentId: string, exitCode: number | undefined) => void) => () => void
       onAgentStateUpdate: (callback: (agents: AgentState[]) => void) => () => void

--- a/src/renderer/electron.d.ts
+++ b/src/renderer/electron.d.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig, AgentState, AgentTheme, HubInfo, PinboardTask, InfoEntry, WorkspacePreset, WorkspaceTheme, Skill, CreateScheduleInput, EditScheduleInput, CommunityTeam, CommunityTeamListItem, CommunityAgent, CommunityCategory, CommunityTheme, CommunityThemeListItem, RespawnResult, InboxMessage, NotificationThreshold, TeamProposal } from '../shared/types'
+import type { AgentConfig, AgentState, AgentTheme, HubInfo, PinboardTask, InfoEntry, WorkspacePreset, WorkspaceTheme, Skill, CreateScheduleInput, EditScheduleInput, CommunityTeam, CommunityTeamListItem, CommunityAgent, CommunityCategory, CommunityTheme, CommunityThemeListItem, RespawnResult, InboxMessage, NotificationThreshold, TeamProposal, TelegramStatus } from '../shared/types'
 
 declare global {
   interface Window {
@@ -73,6 +73,14 @@ declare global {
       regenerateRemoteToken: () => Promise<{ ok: boolean; newUrl?: string | null }>
       onRemoteStatusUpdate: (cb: (status: { enabled: boolean; publicUrl: string | null; lanUrl: string | null; lanEnabled: boolean; connectionCount: number; lastActivity: number | null }) => void) => () => void
       onRemoteSetupProgress: (cb: (progress: { stage: 'downloading' | 'starting' | 'ready' | 'error'; message?: string }) => void) => () => void
+      // Telegram orchestration
+      enableTelegram: () => Promise<void>
+      disableTelegram: () => Promise<void>
+      setTelegramToken: (token: string) => Promise<void>
+      getTelegramPairingCode: () => Promise<string | null>
+      unpairTelegram: (userId: number) => Promise<void>
+      getTelegramStatus: () => Promise<TelegramStatus>
+      onTelegramStatusUpdate: (cb: (status: TelegramStatus) => void) => () => void
       // Stale task alert snooze
       getStaleAlertSnooze: () => Promise<{ muteUntil: number | null }>
       setStaleAlertSnooze: (durationMs: number | null) => Promise<{ muteUntil: number | null }>

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -636,5 +636,7 @@ export interface TelegramStatus {
   enabled: boolean
   hasToken: boolean
   pairedCount: number
+  /** Paired Telegram user IDs — what the Settings unpair list renders. */
+  pairedIds: number[]
   activePairingCode: string | null
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -228,6 +228,14 @@ export const IPC = {
   REMOTE_SETUP_PROGRESS: 'remote:setup-progress',
   REMOTE_LAN_ENABLE: 'remote:lan-enable',
   REMOTE_LAN_DISABLE: 'remote:lan-disable',
+  // Telegram orchestration
+  TELEGRAM_ENABLE: 'telegram:enable',
+  TELEGRAM_DISABLE: 'telegram:disable',
+  TELEGRAM_SET_TOKEN: 'telegram:set-token',
+  TELEGRAM_GET_PAIRING_CODE: 'telegram:get-pairing-code',
+  TELEGRAM_UNPAIR: 'telegram:unpair',
+  TELEGRAM_GET_STATUS: 'telegram:get-status',
+  TELEGRAM_STATUS_UPDATE: 'telegram:status-update',
   // Workshop passcode
   WORKSHOP_SET_PASSCODE: 'workshop:set-passcode',
   WORKSHOP_GET_PASSCODE_SET: 'workshop:get-passcode-set',
@@ -623,3 +631,10 @@ export type RemoteSetupProgress =
   | { stage: 'starting'; message?: string }
   | { stage: 'ready'; message?: string }
   | { stage: 'error'; message?: string }
+
+export interface TelegramStatus {
+  enabled: boolean
+  hasToken: boolean
+  pairedCount: number
+  activePairingCode: string | null
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -282,7 +282,9 @@ export const IPC = {
   PROPOSALS_GET: 'proposals:get',
   PROPOSALS_APPROVE: 'proposals:approve',
   PROPOSALS_REJECT: 'proposals:reject',
+  PROPOSALS_REOPEN: 'proposals:reopen',
   PROPOSAL_ADDED: 'proposals:added',
+  PROPOSAL_RESOLVED: 'proposals:resolved',
   // Trollbox bridge — renderer holds the live Supabase client; main needs
   // a snapshot for the 3DS HTTP API. Push direction = renderer → main on
   // state change. Send direction = main → renderer when 3DS posts a chat.


### PR DESCRIPTION
Adds a full Telegram bridge to The Cog so you can drive your swarm from your phone, plus a desktop fix for team proposals. Everything is decoupled behind small, unit-tested modules and mirrors the existing Remote View conventions.

## What's included

**Telegram bot (long-poll, no tunnel)**
- 🔐 Pairing + allowlist gate — one-time 6-digit code, timing-safe compare, anti-brute-force burn, private-chat-only, relay subscriptions persisted across restart.
- 🐉 Command router with multi-orchestrator ("double-headed dragon") addressing: `/status`, `/use`, `/msg`, `/output`, `/task`, plain text → the chat's active head.
- 📎 Documents & photos → downloaded, saved under `.cog/telegram-inbox/`, and routed to the active agent (text inlined, images handed over as a path).
- 🎙️ Voice notes → transcribed via the app's existing Whisper backend (cloud/local) and routed as text, with a graceful save-the-audio fallback.
- 📥 Inbox mirror: agent output relays to Telegram with urgency badges; a configurable **priority threshold** in Settings controls what reaches your phone (baseline = everything). Conversational replies always relay.
- ⚙️ Settings UI: token setup (validated before persist), enable toggle, pairing code, unpair, threshold.

**Team proposals — actionable everywhere**
- Fixes the desktop dead-end where closing a proposal popup left no way to approve/reject. Inbox entries now show an "Open / Review" button that re-surfaces the modal.
- Proposals push to Telegram with ✅ Approve / ❌ Reject / 📋 Details inline buttons (approve reuses the shared spawn/schedule path).
- A new `PROPOSAL_RESOLVED` broadcast keeps every surface in sync — resolving anywhere (desktop, 3DS, Telegram) auto-closes the popup, drops the inbox button, and edits the Telegram card.

**Maintenance**
- `scripts/encode-bug-token.mjs` — local encoder for rotating the obfuscated bug-report PAT without pasting it anywhere, plus a routine rotation of that token.

## Testing
- 45 unit tests across the telegram module (pairing, routing, attachments, proposal formatting, ANSI, server construction/relay).
- Typechecks clean on both projects (main + renderer) with no new errors.
- A high-effort code-review pass ran over the full branch diff; all confirmed findings were fixed in the final commit (relay regression, proposal-resolve race, unguarded reject, post-pairing subscription, filename collision, caption size-cap, stale inbox button).

## Known limitations (by design, noted for reviewers)
- Approve-from-Telegram spawns the team as-proposed — per-agent trimming stays desktop-only (needs the full UI).
- With multiple paired users, any paired user can approve/reject a broadcast proposal (single-owner trust model assumed).
- A second proposal arriving while a desktop modal is already open isn't queued to the modal (recoverable via the inbox Review button).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KLgD38MuCVnSfNbfjA6cAe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLgD38MuCVnSfNbfjA6cAe)_